### PR TITLE
Code quality - General issues-fix-1

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/connection/AbstractStatelessClient.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/AbstractStatelessClient.java
@@ -321,6 +321,7 @@ public abstract class AbstractStatelessClient<E extends ParameterizeWireKey> imp
                 LOG.info(e.toString());
         } catch (IORuntimeException e) {
             // this can occur if the socket is not currently connected
+            LOG.trace("socket is not currently connected.", e);
         }
     }
 
@@ -335,6 +336,7 @@ public abstract class AbstractStatelessClient<E extends ParameterizeWireKey> imp
                 LOG.info(e.toString());
         } catch (IORuntimeException e) {
             // this can occur if the socket is not currently connected
+            LOG.trace("socket is not currently connected.", e);
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/network/connection/SocketAddressSupplier.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/SocketAddressSupplier.java
@@ -42,7 +42,7 @@ public class SocketAddressSupplier implements Supplier<SocketAddress> {
             this.remoteAddresses.add(new RemoteAddressSupplier(connectURI));
         }
 
-        assert this.remoteAddresses.size() > 0;
+        assert !this.remoteAddresses.isEmpty();
 
         // for (String descriptions : descriptions) {
         this.iterator = remoteAddresses.iterator();

--- a/src/main/java/net/openhft/chronicle/network/connection/TraceLock.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/TraceLock.java
@@ -10,6 +10,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class TraceLock extends ReentrantLock {
 
+    private static final long serialVersionUID = 1997992705529515418L;
     private volatile Throwable here;
 
     public static ReentrantLock create() {

--- a/src/test/java/net/openhft/performance/tests/third/party/frameworks/grizzly/GrizzlyEchoServer.java
+++ b/src/test/java/net/openhft/performance/tests/third/party/frameworks/grizzly/GrizzlyEchoServer.java
@@ -32,7 +32,7 @@ import static org.glassfish.grizzly.nio.transport.TCPNIOTransportBuilder.newInst
  */
 public class GrizzlyEchoServer {
 
-    static final Logger LOG = Logger.getLogger(GrizzlyEchoServer.class.getName());
+    private static final Logger LOG = Logger.getLogger(GrizzlyEchoServer.class.getName());
     static final int PORT = Integer.parseInt(System.getProperty("port", "9124"));
 
     @NotNull


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule: 
squid:S1166 - Exception handlers should preserve the original exception
squid:S1312 - Loggers should be "private static final" and should share a naming convention
squid:S1155 - Collection.isEmpty() should be used to test for emptiness
squid:S2057 - Serializable classes should have a version id

You can find more information about the issue here: 
http://dev.eclipse.org/sonar/rules/show/squid:S1166
http://dev.eclipse.org/sonar/rules/show/squid:S1312
http://dev.eclipse.org/sonar/rules/show/squid:S1155
http://dev.eclipse.org/sonar/rules/show/squid:S2057

Please let me know if you have any questions.

Faisal