### PR TITLE
Fix #46 Stop unsuccessful connection attempts when thread is interrupted

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/AlwaysStartOnPrimaryConnectionStrategy.java
+++ b/src/main/java/net/openhft/chronicle/network/AlwaysStartOnPrimaryConnectionStrategy.java
@@ -84,6 +84,7 @@ public class AlwaysStartOnPrimaryConnectionStrategy extends AbstractMarshallable
 
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                return null;
             } catch (Throwable e) {
                 //noinspection ConstantConditions
                 if (socketChannel != null)

--- a/src/test/java/net/openhft/chronicle/network/AlwaysStartOnPrimaryConnectionStrategyTest.java
+++ b/src/test/java/net/openhft/chronicle/network/AlwaysStartOnPrimaryConnectionStrategyTest.java
@@ -1,0 +1,41 @@
+package net.openhft.chronicle.network;
+
+import net.openhft.chronicle.network.connection.FatalFailureMonitor;
+import net.openhft.chronicle.network.connection.SocketAddressSupplier;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class AlwaysStartOnPrimaryConnectionStrategyTest {
+    private static String uri;
+
+    @After
+    public void teardown() {
+        TCPRegistry.reset();
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        String hostPort = "host.port";
+        TCPRegistry.createServerSocketChannelFor(hostPort);
+        uri = TCPRegistry.acquireServerSocketChannel(hostPort).getLocalAddress().toString();
+    }
+
+    @Test(timeout = 1_000)
+    public void connect_attempts_should_stop_when_thread_is_interrupted() throws InterruptedException {
+        Thread thread = new Thread(() -> {
+            ConnectionStrategy strategy = new AlwaysStartOnPrimaryConnectionStrategy();
+            try {
+                strategy.connect("unavailable_uri", SocketAddressSupplier.uri(uri), false, new FatalFailureMonitor() {});
+            } catch (InterruptedException e) {
+                Assert.fail("AlwaysStartOnPrimaryConnectionStrategy#connect should not have propagated the " + e.getClass());
+            }
+        });
+        thread.start();
+        thread.interrupt();
+        thread.join();
+    }
+}


### PR DESCRIPTION
Maybe this is not a strategically right fix but it works by breaking the infinie loop of connection fails. The fix was tested with Chronicle-Fix engine