### PR TITLE
removed the call to peekContents because this caused a JVM crash

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/cluster/handlers/UberHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/cluster/handlers/UberHandler.java
@@ -173,14 +173,13 @@ public final class UberHandler<T extends ClusteredNetworkContext<T>> extends Csp
             // divert to onTouch (block further reads) if a message is already in progress
             {
                 final SubHandler<T> handler = handler();
-                if( handler != null && handler.inProgress())
-                {
-                    try{
-                        if( false == handler.onTouch(outWire) ) {
+                if (handler != null && handler.inProgress()) {
+                    try {
+                        if (false == handler.onTouch(outWire)) {
                             dc.rollbackOnClose();
                             return;
                         }
-                    }catch( Exception e ) {
+                    } catch (Exception e) {
                         removeHandler(handler);
                     }
                     return;
@@ -201,7 +200,7 @@ public final class UberHandler<T extends ClusteredNetworkContext<T>> extends Csp
                     handler.onInitialize(outWire);
 
                     // trip another read (on the same event) if we're not done yet
-                    if(handler.inProgress()) {
+                    if (handler.inProgress()) {
                         dc.rollbackOnClose();
                         return;
                     }
@@ -230,7 +229,7 @@ public final class UberHandler<T extends ClusteredNetworkContext<T>> extends Csp
                         "process the following " +
                         "YAML\n");
         } catch (Throwable e) {
-            Jvm.warn().on(getClass(), "failed to parse:" + peekContents(dc), e);
+              Jvm.warn().on(getClass(), e);
         }
     }
 


### PR DESCRIPTION
J 5385% c2 net.openhft.chronicle.wire.BinaryWire.lambda$copyOne$2(Lnet/openhft/chronicle/wire/WireOut;JJLnet/openhf
00007f78f8b0a180+0x0000000000000354]
j  net.openhft.chronicle.wire.BinaryWire$$Lambda$511.writeValue(Lnet/openhft/chronicle/wire/ValueOut;)V+17
J 5001 c2 net.openhft.chronicle.wire.BinaryWire.copyOne(Lnet/openhft/chronicle/wire/WireOut;)V (751 bytes) @ 0x0000
J 4905 c2 net.openhft.chronicle.wire.BinaryWire.readWithLength(Lnet/openhft/chronicle/wire/WireOut;I)V (205 bytes) 
J 5001 c2 net.openhft.chronicle.wire.BinaryWire.copyOne(Lnet/openhft/chronicle/wire/WireOut;)V (751 bytes) @ 0x0000
J 4905 c2 net.openhft.chronicle.wire.BinaryWire.readWithLength(Lnet/openhft/chronicle/wire/WireOut;I)V (205 bytes) 
J 5001 c2 net.openhft.chronicle.wire.BinaryWire.copyOne(Lnet/openhft/chronicle/wire/WireOut;)V (751 bytes) @ 0x0000
J 5266 c2 net.openhft.chronicle.wire.WireDumper.dumpOne(Ljava/lang/StringBuilder;Lnet/openhft/chronicle/bytes/Bytes
00000001fd4]
J 5190 c1 net.openhft.chronicle.wire.WireDumper.asString(JJZ)Ljava/lang/String; (259 bytes) @ 0x00007f78f1b2bf24 [0
J 5177 c1 net.openhft.chronicle.wire.BinaryWire.readingPeekYaml()Ljava/lang/String; (28 bytes) @ 0x00007f78f1b1f71c
J 5227 c1 net.openhft.chronicle.network.cluster.handlers.UberHandler.peekContents(Lnet/openhft/chronicle/wire/Docum
x00007f78f1b4dfa0+0x00000000000001a4]
J 4289 c2 net.openhft.chronicle.network.cluster.handlers.UberHandler.onRead(Lnet/openhft/chronicle/wire/DocumentCon
f78f8967804 [0x00007f78f8966f40+0x00000000000008c4]
J 4134 c2 net.openhft.chronicle.network.WireTcpHandler.onRead0()V (456 bytes) @ 0x00007f78f89316cc [0x00007f78f8931
J 4250 c2 net.openhft.chronicle.network.WireTcpHandler.process(Lnet/openhft/chronicle/bytes/Bytes;Lnet/openhft/chro
V (346 bytes) @ 0x00007f78f87af404 [0x00007f78f87af220+0x00000000000001e4]
J 4109 c2 net.openhft.chronicle.network.TcpEventHandler.invokeHandler()Z (319 bytes) @ 0x00007f78f891f444 [0x00007f
J 4124 c2 net.openhft.chronicle.network.TcpEventHandler.readAction(Z)Z (382 bytes) @ 0x00007f78f892eb08 [0x00007f78
J 4107 c2 net.openhft.chronicle.threads.MediumEventLoop.runAllMediumHandler()Z (196 bytes) @ 0x00007f78f8924ab4 [0x
J 4251% c2 net.openhft.chronicle.threads.MediumEventLoop.runLoop()V (164 bytes) @ 0x00007f78f8961e08 [0x00007f78f89
j  net.openhft.chronicle.threads.MediumEventLoop.run()V+37
j  java.util.concurrent.Executors$RunnableAdapter.call()Ljava/lang/Object;+4 java.base@11.0.2
j  java.util.concurrent.FutureTask.run()V+39 java.base@11.0.2
j  java.util.concurrent.ThreadPoolExecutor.runWorker(Ljava/util/concurrent/ThreadPoolExecutor$Worker;)V+92 java.bas
j  java.util.concurrent.ThreadPoolExecutor$Worker.run()V+5 java.base@11.0.2
j  java.lang.Thread.run()V+11 java.base@11.0.2
j  net.openhft.chronicle.core.threads.CleaningThread.run()V+1
v  ~StubRoutines::call_stub
V  [libjvm.so+0x8847e9]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, Thread*)+0x3b9
V  [libjvm.so+0x88279d]  JavaCalls::call_virtual(JavaValue*, Handle, Klass*, Symbol*, Symbol*, Thread*)+0x1ed
V  [libjvm.so+0x92c85c]  thread_entry(JavaThread*, Thread*)+0x6c
V  [libjvm.so+0xdc2b0d]  JavaThread::thread_main_inner()+0x21d
V  [libjvm.so+0xdc2eb7]  JavaThread::run()+0x377
V  [libjvm.so+0xc076a0]  thread_native_entry(Thread*)+0xf0