### PR TITLE
Fix IndexOutofbounds Exception for Benchmarks

### DIFF
--- a/src/test/java/net/openhft/performance/tests/third/party/frameworks/grizzly/GrizzlyClientLatencyTest.java
+++ b/src/test/java/net/openhft/performance/tests/third/party/frameworks/grizzly/GrizzlyClientLatencyTest.java
@@ -89,7 +89,7 @@ public class GrizzlyClientLatencyTest extends NetworkTestCommon {
                 Buffer msg = ctx.<Buffer>getMessage();
                 if (msg.remaining() >= 8) {
                     if (count % 10000 == 0)
-                       // System.out.print(".");
+                        System.out.print(".");
 
                     if (count >= 0) {
                         times[count] = System.nanoTime() - msg.getLong();

--- a/src/test/java/net/openhft/performance/tests/third/party/frameworks/mina/MinaClientLatencyTest.java
+++ b/src/test/java/net/openhft/performance/tests/third/party/frameworks/mina/MinaClientLatencyTest.java
@@ -71,7 +71,7 @@ public class MinaClientLatencyTest extends NetworkTestCommon {
             public void messageReceived(@NotNull IoSession session, @NotNull Object msg) {
                 if (((IoBuffer) msg).remaining() >= 8) {
                     if (count % 10000 == 0)
-                       // System.out.print(".");
+                        System.out.print(".");
 
                     if (count >= 0) {
                         times[count] = System.nanoTime() - ((IoBuffer) msg).getLong();

--- a/src/test/java/net/openhft/performance/tests/third/party/frameworks/netty/NettyClientLatencyTest.java
+++ b/src/test/java/net/openhft/performance/tests/third/party/frameworks/netty/NettyClientLatencyTest.java
@@ -113,7 +113,7 @@ public final class NettyClientLatencyTest extends NetworkTestCommon {
 
                 if (((ByteBuf) msg).readableBytes() >= 8) {
                     if (count % 10000 == 0)
-                       // System.out.print(".");
+                        System.out.print(".");
 
                     if (count >= 0) {
                         times[count] = System.nanoTime() - ((ByteBuf) msg).readLong();


### PR DESCRIPTION
Restore the status bar and fixes IndexOutofbound exception
when the benchmarks are executed.