### PR TITLE
POC for thread-safe add listener method (Do not merge)

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/WireTcpHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/WireTcpHandler.java
@@ -119,6 +119,9 @@ public abstract class WireTcpHandler<T extends NetworkContext<T>>
         if (outWire.bytes().writePosition() != lastWritePosition)
             onBytesWritten();
 
+        // Run any new connection listeners
+        runNewConnectionListeners();
+
         if (publisher != null)
             publisher.applyAction(outWire);
 
@@ -131,6 +134,9 @@ public abstract class WireTcpHandler<T extends NetworkContext<T>>
     }
 
     protected void onBytesWritten() {
+    }
+
+    protected void runNewConnectionListeners() {
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/network/cluster/handlers/UberHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/cluster/handlers/UberHandler.java
@@ -242,6 +242,13 @@ public final class UberHandler<T extends ClusteredNetworkContext<T>> extends Csp
     }
 
     @Override
+    protected void runNewConnectionListeners() {
+        if (connectionChangedNotifier != null) {
+            connectionChangedNotifier.executeAndActivateNewConnectionChangeListeners();
+        }
+    }
+
+    @Override
     protected void onBytesWritten() {
         onMessageReceivedOrWritten();
     }


### PR DESCRIPTION
This approach works, and is functionally equivalent to what was there previously, but stops executing new listeners synchronously. I think its better from an API perspective.

I don't like how I had to put that hook into `WireTCPHandler`, that needs some more thinking. This is by no means ready for prime time, but keen to get your thoughts on the approach. Feel free to forward to anyone else who might have an opinion.