### PR TITLE
Make initial table size larger to avoid resizing

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/internal/lookuptable/FileBasedHostnamePortLookupTable.java
+++ b/src/main/java/net/openhft/chronicle/network/internal/lookuptable/FileBasedHostnamePortLookupTable.java
@@ -28,6 +28,7 @@ import static net.openhft.chronicle.core.util.Time.sleep;
  */
 public class FileBasedHostnamePortLookupTable implements HostnamePortLookupTable, java.io.Closeable {
 
+    private static final long MINIMUM_INITIAL_FILE_SIZE_BYTES = 1_024 * 512; // We want to prevent resizing
     private static final long LOCK_TIMEOUT_MS = 10_000;
     private static final int DELETE_TABLE_FILE_TIMEOUT_MS = 1_000;
     private static final int PID = Jvm.getProcessId();
@@ -48,7 +49,8 @@ public class FileBasedHostnamePortLookupTable implements HostnamePortLookupTable
             if (sharedTableFile.createNewFile() && !sharedTableFile.canWrite()) {
                 throw new IllegalStateException("Cannot write to shared mapping file " + sharedTableFile);
             }
-            sharedTableBytes = MappedBytes.mappedBytes(sharedTableFile, OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, false);
+            long pagesForMinimum = (long) Math.ceil(((float) MINIMUM_INITIAL_FILE_SIZE_BYTES) / OS.SAFE_PAGE_SIZE);
+            sharedTableBytes = MappedBytes.mappedBytes(sharedTableFile, pagesForMinimum * OS.SAFE_PAGE_SIZE, OS.SAFE_PAGE_SIZE, false);
             sharedTableBytes.disableThreadSafetyCheck(true);
             sharedTableWire = new YamlWire(sharedTableBytes);
             sharedTableWire.consumePadding();
@@ -161,11 +163,15 @@ public class FileBasedHostnamePortLookupTable implements HostnamePortLookupTable
         for (count = 1; System.currentTimeMillis() < timeoutAt; count++) {
             try (FileLock fileLock = sharedTableBytes.mappedFile().tryLock(0, Long.MAX_VALUE, shared)) {
                 if (fileLock != null) {
-                    T t = supplier.get();
-                    long elapsedMs = System.currentTimeMillis() - startMs;
-                    if (elapsedMs > 100)
-                        Jvm.warn().on(getClass(), "Took " + elapsedMs / 1000.0 + " seconds to obtain the lock on " + sharedTableFile, lastThrown);
-                    return t;
+                    try {
+                        T t = supplier.get();
+                        long elapsedMs = System.currentTimeMillis() - startMs;
+                        if (elapsedMs > 100)
+                            Jvm.warn().on(getClass(), "Took " + elapsedMs / 1000.0 + " seconds to obtain the lock on " + sharedTableFile, lastThrown);
+                        return t;
+                    } catch (OverlappingFileLockException e) {
+                        throw new RuntimeException("Attempted to resize the underlying bytes, increase the MINIMUM_INITIAL_FILE_SIZE_BYTES or make this work with resizing!", e);
+                    }
                 }
             } catch (IOException | OverlappingFileLockException e) {
                 // failed to acquire the lock, wait until other operation completes

--- a/src/test/java/net/openhft/chronicle/network/internal/lookuptable/FileBasedHostnamePortLookupTableTest.java
+++ b/src/test/java/net/openhft/chronicle/network/internal/lookuptable/FileBasedHostnamePortLookupTableTest.java
@@ -4,7 +4,6 @@ import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.core.io.IOTools;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -74,7 +73,6 @@ public class FileBasedHostnamePortLookupTableTest {
         assertEquals(new HashSet<>(Arrays.asList("aaa", "bbb", "ccc")), allValues);
     }
 
-    @Ignore(/*OverlappingFileLockException in FileBasedHostnamePortLookupTable #114*/)
     @Test(timeout = 20_000)
     public void shouldWorkConcurrently() {
         int para = doShouldWorkConcurrently(true);
@@ -85,7 +83,7 @@ public class FileBasedHostnamePortLookupTableTest {
 
     public int doShouldWorkConcurrently(boolean parallel) {
         long start = System.currentTimeMillis();
-        IntStream stream = IntStream.range(0, Runtime.getRuntime().availableProcessors());
+        IntStream stream = IntStream.range(0, Math.min(16, Runtime.getRuntime().availableProcessors()));
         if (parallel)
             stream = stream.parallel();
 
@@ -94,7 +92,7 @@ public class FileBasedHostnamePortLookupTableTest {
             for (int i = 0; i < 50 && start + 2000 > System.currentTimeMillis(); i++) {
                 String description = format("0." + (parallel ? "1" : "0") + ".%d.%d", myId, i);
                 allMyAliases.add(description);
-                InetSocketAddress address = new InetSocketAddress(description, i);
+                InetSocketAddress address = InetSocketAddress.createUnresolved(description, i);
                 lookupTable.put(description, address);
                 InetSocketAddress lookup = lookupTable.lookup(description);
                 assertNotNull(description, lookup);


### PR DESCRIPTION
This works around #114

It was confusing what was happening here, the `OverlappingFileLockException` was because the lookup table had acquired the lock, then `net.openhft.chronicle.bytes.MappedFile#resizeRafIfTooSmall` was attempting to acquire the lock because the table had filled up and needed to grow. This propagated to the outer loop and the lookup table kept trying to write the file because it thought it was just blocked by another process.

This doesn't fix the problem, but it works around it for all sensible cases (the initial table size is now 512KiB) and if it does occur throws a runtime exception with a meaningful message.

I decided not to fix it because this table is just a utility for testing, If we think it would be used in production it would be better to fix it properly (e.g. stop using OS file locks for mutual exclusion of processes)

I also create InetSocketAddresses unresolved to lighten the load on DNS in that tight loop.

And put an upper bound of 16 on the concurrent threads, so it doesn't break when it runs on a machine with a large amount of cores.