### PR TITLE
Execute new connection listeners on TCPEventHandler thread, Fixes #109

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/api/TcpHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/api/TcpHandler.java
@@ -54,4 +54,11 @@ public interface TcpHandler<N extends NetworkContext<N>> extends ClientClosedPro
 
     default void onReadComplete() {
     }
+
+    /**
+     * Perform any low priority work, called when the handler is not busy, or after it has been
+     * busy for a long time.
+     */
+    default void performIdleWork() {
+    }
 }

--- a/src/test/java/net/openhft/chronicle/network/cluster/ConnectionManagerTest.java
+++ b/src/test/java/net/openhft/chronicle/network/cluster/ConnectionManagerTest.java
@@ -1,0 +1,119 @@
+package net.openhft.chronicle.network.cluster;
+
+import net.openhft.chronicle.core.io.Closeable;
+import net.openhft.chronicle.network.NetworkTestCommon;
+import net.openhft.chronicle.network.VanillaNetworkContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConnectionManagerTest extends NetworkTestCommon {
+
+    private ConnectionManager<TestNetworkContext> connectionManager;
+    private TestNetworkContext networkContext;
+
+    @Mock
+    private ConnectionManager.ConnectionListener<TestNetworkContext> listener1;
+    @Mock
+    private ConnectionManager.ConnectionListener<TestNetworkContext> listener2;
+
+    @Before
+    public void setUp() {
+        connectionManager = new ConnectionManager<>();
+        networkContext = new TestNetworkContext();
+    }
+
+    @After
+    public void tearDown() {
+        Closeable.closeQuietly(networkContext);
+    }
+
+    @Test
+    public void onConnectionChangedExecutesAllListeners() {
+        connectionManager.addListener(listener1);
+        connectionManager.addListener(listener2);
+        connectionManager.onConnectionChanged(true, networkContext, null);
+        verify(listener1).onConnectionChange(networkContext, true);
+        verify(listener2).onConnectionChange(networkContext, true);
+    }
+
+    @Test
+    public void onConnectionChangedOnlyExecutesListenersWhenConnectionStateChanges() {
+        connectionManager.addListener(listener1);
+        connectionManager.addListener(listener2);
+        ConnectionManager.EventEmitterToken token = connectionManager.onConnectionChanged(true, networkContext, null);
+        verify(listener1).onConnectionChange(networkContext, true);
+        verify(listener2).onConnectionChange(networkContext, true);
+        connectionManager.onConnectionChanged(true, networkContext, token);
+        verify(listener1).onConnectionChange(networkContext, true);
+        verify(listener2).onConnectionChange(networkContext, true);
+        connectionManager.onConnectionChanged(false, networkContext, token);
+        verify(listener1).onConnectionChange(networkContext, false);
+        verify(listener2).onConnectionChange(networkContext, false);
+        verifyNoMoreInteractions(listener1, listener2);
+    }
+
+    @Test
+    public void executeNewListenersWillOnlyExecuteNonExecutedListeners() {
+        connectionManager.addListener(listener1);
+        ConnectionManager.EventEmitterToken token = connectionManager.onConnectionChanged(true, networkContext, null);
+        connectionManager.onConnectionChanged(true, networkContext, token);
+        verify(listener1).onConnectionChange(networkContext, true);
+        connectionManager.addListener(listener2);
+        connectionManager.executeNewListeners(networkContext, token);
+        verify(listener1).onConnectionChange(networkContext, true);
+        verify(listener2).onConnectionChange(networkContext, true);
+        connectionManager.executeNewListeners(networkContext, token);
+        verify(listener1).onConnectionChange(networkContext, true);
+        verify(listener2).onConnectionChange(networkContext, true);
+        verifyNoMoreInteractions(listener1, listener2);
+    }
+
+    @Test
+    public void executeNewListenersWillExecuteAllListenersOnFirstCall() {
+        final ConnectionManager.EventEmitterToken eventEmitterToken = connectionManager.onConnectionChanged(true, networkContext, null);
+        connectionManager.addListener(listener1);
+        connectionManager.addListener(listener2);
+        connectionManager.executeNewListeners(networkContext, eventEmitterToken);
+        verify(listener1).onConnectionChange(networkContext, true);
+        verify(listener2).onConnectionChange(networkContext, true);
+    }
+
+    @Test
+    public void executeNewListenersWillNotExecuteListenersThatPreviouslyThrewIllegalStateException() {
+        doThrow(IllegalStateException.class).when(listener2).onConnectionChange(any(), anyBoolean());
+        final ConnectionManager.EventEmitterToken eventEmitterToken = connectionManager.onConnectionChanged(true, networkContext, null);
+        connectionManager.addListener(listener1);
+        connectionManager.addListener(listener2);
+        connectionManager.executeNewListeners(networkContext, eventEmitterToken);
+        verify(listener1).onConnectionChange(networkContext, true);
+        verify(listener2).onConnectionChange(networkContext, true);
+    }
+
+    @Test
+    public void onConnectionChangedWorksWhenThereAreNoListeners() {
+        final ConnectionManager.EventEmitterToken token = connectionManager.onConnectionChanged(true, networkContext, null);
+        connectionManager.addListener(listener1);
+        connectionManager.onConnectionChanged(false, networkContext, token);
+        verify(listener1).onConnectionChange(networkContext, false);
+    }
+
+    @Test
+    public void executeNewListenersWorksWhenThereAreNoListeners() {
+        final ConnectionManager.EventEmitterToken token = connectionManager.onConnectionChanged(true, networkContext, null);
+        connectionManager.executeNewListeners(networkContext, token);
+        connectionManager.addListener(listener1);
+        connectionManager.executeNewListeners(networkContext, token);
+        verify(listener1).onConnectionChange(networkContext, true);
+    }
+
+    static class TestNetworkContext extends VanillaNetworkContext<TestNetworkContext> {
+    }
+}


### PR DESCRIPTION
Fixes #109 

## Main points
- State required for idempotency moved out of ConnectionManager (would have been a small(?) memory leak previously)
- Will work with any ServerThreadingStrategy (including concurrent)
- Checks for new listeners should be fast in the event there are none (just an integer comparison, synchronized block only entered if there are new listeners to execute)
- onConnectionChanged should now only enter synchronized block if the state has actually changed

## Note to reviewers
One thing that I thought might be a risk was this implementation associates the state required for idempotency with the UberHandler (the `eventEmitterToken` field), where previously the last known state was stored in a map keyed by `NetworkContext`. If a single `NetworkContext` was able to be associated with multiple `UberHandlers` (simultaneously or sequentially) then that would be a change in behaviour, and potentially not idempotent. But from what I can see this is not the case and `UberHandlers` are 1:1 with `NetworkContexts`.