### PR TITLE
Disconnect UberHandler when host ID mismatched

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/HeaderTcpHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/HeaderTcpHandler.java
@@ -53,8 +53,7 @@ public class HeaderTcpHandler<T extends NetworkContext<T>> extends SimpleCloseab
                         @NotNull final T nc) {
         throwExceptionIfClosed();
 
-        WireType wireType = nc.wireType() == null ? WireType.BINARY :  nc.wireType();
-      // assert wireType != null;
+        WireType wireType = nc.wireType() == null ? WireType.BINARY : nc.wireType();
 
         // the type of the header
         final Wire inWire = wireType.apply(in);
@@ -87,7 +86,6 @@ public class HeaderTcpHandler<T extends NetworkContext<T>> extends SimpleCloseab
                 ((NetworkContextManager<T>) handler).nc(nc);
 
             handlerManager.tcpHandler(handler);
-
         } catch (Throwable e) {
             if (isClosed())
                 return;

--- a/src/main/java/net/openhft/chronicle/network/cluster/handlers/UberHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/cluster/handlers/UberHandler.java
@@ -66,9 +66,7 @@ public final class UberHandler<T extends ClusteredNetworkContext<T>> extends Csp
         this.localIdentifier = localIdentifier;
         this.remoteIdentifier = remoteIdentifier;
 
-        assert remoteIdentifier != localIdentifier :
-                "remoteIdentifier=" + remoteIdentifier + ", " +
-                        "localIdentifier=" + localIdentifier;
+        checkRemoteAndLocalIdentifiersAreNotEqual();
         wireType(wireType);
     }
 
@@ -113,10 +111,7 @@ public final class UberHandler<T extends ClusteredNetworkContext<T>> extends Csp
         nc.wireType(wireType());
         isAcceptor(nc.isAcceptor());
 
-        assert checkIdentifierEqualsHostId();
-        assert remoteIdentifier != localIdentifier :
-                "remoteIdentifier=" + remoteIdentifier + ", " +
-                        "localIdentifier=" + localIdentifier;
+        validateIdentifiers();
 
         @NotNull final WireOutPublisher publisher = nc.wireOutPublisher();
         publisher(publisher);
@@ -134,11 +129,23 @@ public final class UberHandler<T extends ClusteredNetworkContext<T>> extends Csp
         }
     }
 
-    private boolean checkIdentifierEqualsHostId() {
+    private void validateIdentifiers() {
+        checkIdentifierEqualsHostId();
+        checkRemoteAndLocalIdentifiersAreNotEqual();
+    }
+
+    private void checkRemoteAndLocalIdentifiersAreNotEqual() {
+        if (remoteIdentifier == localIdentifier) {
+            throw new IllegalArgumentException("remoteIdentifier=" + remoteIdentifier + ", " +
+                    "localIdentifier=" + localIdentifier);
+        }
+    }
+
+    private void checkIdentifierEqualsHostId() {
         byte localHostIdentifier = nc().getLocalHostIdentifier();
         if (localIdentifier != localHostIdentifier && localHostIdentifier != 0)
-            throw new AssertionError("localId: " + localIdentifier + " != nc().localId: " + localHostIdentifier);
-        return true;
+            throw new IllegalArgumentException("Received a handler for host ID: "
+                    + localIdentifier + ", my host ID is: " + localHostIdentifier + " this is probably a configuration error");
     }
 
     private void notifyConnectionListeners() {

--- a/src/test/java/net/openhft/chronicle/network/UberHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/network/UberHandlerTest.java
@@ -10,6 +10,7 @@ import net.openhft.chronicle.network.cluster.AbstractSubHandler;
 import net.openhft.chronicle.network.cluster.Cluster;
 import net.openhft.chronicle.network.cluster.HostDetails;
 import net.openhft.chronicle.network.cluster.VanillaClusteredNetworkContext;
+import net.openhft.chronicle.network.cluster.handlers.UberHandler;
 import net.openhft.chronicle.network.connection.CoreFields;
 import net.openhft.chronicle.network.connection.VanillaWireOutPublisher;
 import net.openhft.chronicle.threads.Pauser;
@@ -31,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class UberHandlerTest extends NetworkTestCommon {
@@ -88,6 +90,12 @@ public class UberHandlerTest extends NetworkTestCommon {
         }
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorWillThrowIfLocalAndRemoteIdentifiersAreTheSame() {
+        Wire wire = new BinaryWire(Bytes.allocateElasticOnHeap());
+        UberHandler.uberHandler(123, 123, WireType.BINARY).writeMarshallable(wire);
+    }
+
     private void stopAndWaitTillAllHandlersEnd() throws TimeoutException {
         running.set(false);
         TimingPauser pauser = Pauser.balanced();
@@ -100,6 +108,35 @@ public class UberHandlerTest extends NetworkTestCommon {
 
     private boolean pingPongsAllCompletedAtLeastOneRound() {
         return countersPerCid.size() == NUM_HANDLERS && countersPerCid.values().stream().allMatch(val -> val > 0);
+    }
+
+    @Test
+    public void testHandlerWillCloseWhenHostIdsAreWrong() throws IOException {
+        expectException("Received a handler for host ID: 98, my host ID is: 1 this is probably a configuration error");
+        expectException("Closed");
+        expectException("SubHandler HeartbeatHandler");
+
+        TCPRegistry.createServerSocketChannelFor("initiator", "acceptor");
+        HostDetails initiatorHost = new HostDetails().hostId(99).connectUri("initiator");
+        HostDetails acceptorHost = new HostDetails().hostId(1).connectUri("acceptor");
+        HostDetails acceptorHostWithInvalidId = new HostDetails().hostId(98).connectUri("acceptor");
+
+        try (MyClusterContext acceptorCtx = clusterContext(acceptorHost, initiatorHost);
+             MyClusterContext initiatorCtx = clusterContext(initiatorHost, acceptorHostWithInvalidId)) {
+
+            acceptorCtx.cluster().start(acceptorHost.hostId());
+            initiatorCtx.cluster().start(initiatorHost.hostId());
+
+            AtomicBoolean establishedConnection = new AtomicBoolean(false);
+            initiatorCtx.connectionManager(acceptorHostWithInvalidId.hostId()).addListener((nc, isConnected) -> {
+                if (isConnected) {
+                    establishedConnection.set(true);
+                }
+            });
+            Jvm.pause(2000);
+            assertFalse(establishedConnection.get());
+            assertTrue(exceptions.keySet().stream().anyMatch(k -> k.throwable != null && k.throwable.getMessage().contains("Received a handler for host ID: 98, my host ID is: 1 this is probably a configuration error")));
+        }
     }
 
     private void sendPingPong(WireOut wireOut, int cid) {

--- a/src/test/java/net/openhft/chronicle/network/cluster/handlers/HeartbeatHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/network/cluster/handlers/HeartbeatHandlerTest.java
@@ -1,0 +1,62 @@
+package net.openhft.chronicle.network.cluster.handlers;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.wire.BinaryWire;
+import net.openhft.chronicle.wire.Wire;
+import org.junit.Test;
+
+public class HeartbeatHandlerTest {
+
+    public static final long CID = 1234L;
+    public static final int VALID_HEARTBEAT_TIMEOUT_MS = 1000;
+    public static final int VALID_HEARTBEAT_INTERVAL_MS = 500;
+    public static final int TOO_SMALL_HEARTBEAT_TIMEOUT_MS = 999;
+    public static final int TOO_SMALL_HEARTBEAT_INTERVAL_MS = 499;
+
+    @Test(expected = IllegalArgumentException.class)
+    public void tooSmallHeartbeatIntervalMsThrowsIllegalArgumentException() {
+        HeartbeatHandler.heartbeatHandler(VALID_HEARTBEAT_TIMEOUT_MS, TOO_SMALL_HEARTBEAT_INTERVAL_MS, CID);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void tooSmallHeartbeatIntervalMsThrowsIllegalArgumentExceptionConstructor() {
+        createByDeserialization(VALID_HEARTBEAT_TIMEOUT_MS, TOO_SMALL_HEARTBEAT_INTERVAL_MS);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void tooSmallHeartbeatTimeoutMsThrowsIllegalArgumentException() {
+        HeartbeatHandler.heartbeatHandler(TOO_SMALL_HEARTBEAT_TIMEOUT_MS, VALID_HEARTBEAT_INTERVAL_MS, CID);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void tooSmallHeartbeatTimeoutMsThrowsIllegalArgumentExceptionConstructor() {
+        createByDeserialization(TOO_SMALL_HEARTBEAT_TIMEOUT_MS, VALID_HEARTBEAT_INTERVAL_MS);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void intervalEqualToTimeoutThrowsIllegalStateException() {
+        HeartbeatHandler.heartbeatHandler(VALID_HEARTBEAT_TIMEOUT_MS, VALID_HEARTBEAT_TIMEOUT_MS, CID);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void intervalEqualToTimeoutThrowsIllegalStateExceptionConstructor() {
+        createByDeserialization(VALID_HEARTBEAT_TIMEOUT_MS, VALID_HEARTBEAT_TIMEOUT_MS);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void intervalGreaterThanTimeoutThrowsIllegalStateException() {
+        HeartbeatHandler.heartbeatHandler(VALID_HEARTBEAT_TIMEOUT_MS, VALID_HEARTBEAT_TIMEOUT_MS + 100, CID);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void intervalGreaterThanTimeoutThrowsIllegalStateExceptionConstructor() {
+        createByDeserialization(VALID_HEARTBEAT_TIMEOUT_MS, VALID_HEARTBEAT_TIMEOUT_MS + 100);
+    }
+
+    private void createByDeserialization(long heartbeatTimeoutMs, long heartbeatIntervalMs) {
+        Wire wire = new BinaryWire(Bytes.elasticByteBuffer());
+        wire.write("heartbeatTimeoutMs").int64(heartbeatTimeoutMs);
+        wire.write("heartbeatIntervalMs").int64(heartbeatIntervalMs);
+        new HeartbeatHandler<>(wire);
+    }
+}


### PR DESCRIPTION
 Fixes #124 

This causes the TcpEventHandler to disconnect when an UberHandler is received with a localHostId that doesn't match that of the local host. This used to be an assertion, but because it would likely result from a configuration error, it seemed like it should also be checked in production.

I had to add a way for a TcpHandler to signal to a TcpEventHandler that it should terminate the collection. Keen to get a review on that approach, there may be an existing, better way?

Also validate HeartbeatHandler configuration on construction