### PR TITLE
Use isClosing instead of isClosed to guard actions that rely on a not-closed event loop

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/AcceptorEventHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/AcceptorEventHandler.java
@@ -76,7 +76,7 @@ public class AcceptorEventHandler<T extends NetworkContext<T>> extends AbstractC
 
     @Override
     public boolean action() throws InvalidEventHandlerException {
-        if (!ssc.isOpen() || isClosed() || eventLoop.isClosed())
+        if (!ssc.isOpen() || isClosed() || eventLoop.isClosing())
             throw new InvalidEventHandlerException();
 
         try {
@@ -85,7 +85,7 @@ public class AcceptorEventHandler<T extends NetworkContext<T>> extends AbstractC
             final ChronicleSocketChannel sc = acceptStrategy.accept(ssc);
 
             if (sc != null) {
-                if (isClosed() || eventLoop.isClosed()) {
+                if (isClosed() || eventLoop.isClosing()) {
                     Closeable.closeQuietly(sc);
                     throw new InvalidEventHandlerException("closed");
                 }
@@ -109,7 +109,7 @@ public class AcceptorEventHandler<T extends NetworkContext<T>> extends AbstractC
         } catch (
                 Exception e) {
 
-            if (!isClosed() && !eventLoop.isClosed()) {
+            if (!isClosed() && !eventLoop.isClosing()) {
                 final ChronicleServerSocket socket = ssc.socket();
                 LOGGER.warn("{}, port={}", hostPort, socket == null ? "unknown" : socket.getLocalPort(), e);
             }

--- a/src/main/java/net/openhft/chronicle/network/RemoteConnector.java
+++ b/src/main/java/net/openhft/chronicle/network/RemoteConnector.java
@@ -132,7 +132,7 @@ public class RemoteConnector<T extends NetworkContext<T>> extends SimpleCloseabl
         public boolean action() throws InvalidEventHandlerException {
             throwExceptionIfClosed();
 
-            if (isClosed() || eventLoop.isClosed())
+            if (isClosed() || eventLoop.isClosing())
                 throw InvalidEventHandlerException.reusable();
             final long time = System.currentTimeMillis();
 
@@ -180,7 +180,7 @@ public class RemoteConnector<T extends NetworkContext<T>> extends SimpleCloseabl
                 nextPeriod.set(System.currentTimeMillis() + retryInterval);
                 return false;
             }
-            if (isClosed() || eventLoop.isClosed() || Thread.currentThread().isInterrupted())
+            if (isClosed() || eventLoop.isClosing() || Thread.currentThread().isInterrupted())
                 // we have died.
                 closeQuietly(eventHandler);
             else {

--- a/src/main/java/net/openhft/chronicle/network/TcpEventHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/TcpEventHandler.java
@@ -153,7 +153,7 @@ public class TcpEventHandler<T extends NetworkContext<T>>
         try {
             eventLoop.addHandler(statusMonitorEventHandler);
         } catch (Exception e) {
-            if (!eventLoop.isClosed())
+            if (!eventLoop.isClosing())
                 throw Jvm.rethrow(e);
         }
     }

--- a/src/main/java/net/openhft/chronicle/network/cluster/ClusterAcceptorEventHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/cluster/ClusterAcceptorEventHandler.java
@@ -45,7 +45,7 @@ public class ClusterAcceptorEventHandler<C extends ClusterContext<C, T>, T exten
 
     @Override
     public boolean action() throws InvalidEventHandlerException {
-        if (!ssc.isOpen() || isClosed() || eventLoop.isClosed())
+        if (!ssc.isOpen() || isClosed() || eventLoop.isClosing())
             throw new InvalidEventHandlerException();
 
         try {
@@ -54,7 +54,7 @@ public class ClusterAcceptorEventHandler<C extends ClusterContext<C, T>, T exten
             final ChronicleSocketChannel sc = ssc.accept();
 
             if (sc != null) {
-                if (isClosed() || eventLoop.isClosed()) {
+                if (isClosed() || eventLoop.isClosing()) {
                     closeQuietly(sc);
                     throw new InvalidEventHandlerException("closed");
                 }
@@ -80,7 +80,7 @@ public class ClusterAcceptorEventHandler<C extends ClusterContext<C, T>, T exten
             else
                 throw new InvalidEventHandlerException(e);
         } catch (Exception e) {
-            if (!isClosed() && !eventLoop.isClosed()) {
+            if (!isClosed() && !eventLoop.isClosing()) {
                 final ChronicleServerSocket socket = ssc.socket();
                 LOGGER.warn("{}, port={}", hostPort, socket == null ? "unknown" : socket.getLocalPort(), e);
             }

--- a/src/main/java/net/openhft/chronicle/network/cluster/HostConnector.java
+++ b/src/main/java/net/openhft/chronicle/network/cluster/HostConnector.java
@@ -110,7 +110,7 @@ public class HostConnector<T extends ClusteredNetworkContext<T>, C extends Clust
             return;
         }
 
-        if (eventLoop.isClosed())
+        if (eventLoop.isClosing())
             return;
 
         closeQuietly(nc);

--- a/src/main/java/net/openhft/chronicle/network/cluster/handlers/HeartbeatHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/cluster/handlers/HeartbeatHandler.java
@@ -85,7 +85,7 @@ public final class HeartbeatHandler<T extends ClusteredNetworkContext<T>> extend
     @Override
     public void onInitialize(@NotNull WireOut outWire) {
 
-        if (nc().eventLoop().isClosed())
+        if (nc().eventLoop().isClosing())
             return;
 
         if (nc().isAcceptor())

--- a/src/main/java/net/openhft/chronicle/network/cluster/handlers/UberHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/cluster/handlers/UberHandler.java
@@ -122,7 +122,7 @@ public final class UberHandler<T extends ClusteredNetworkContext<T>> extends Csp
         publisher(publisher);
 
         @NotNull final EventLoop eventLoop = nc.eventLoop();
-        if (!eventLoop.isClosed() && !eventLoop.isClosing()) {
+        if (!eventLoop.isClosing()) {
             eventLoop.start();
 
             // reflect the uber handler


### PR DESCRIPTION
If OpenHFT/Chronicle-Core#238 is correct, then these changes will reduce flakiness in tests due to interactions with closing event loops.