### PR TITLE
Don't close VanillaNetworkContext in the background

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/VanillaNetworkContext.java
+++ b/src/main/java/net/openhft/chronicle/network/VanillaNetworkContext.java
@@ -49,7 +49,7 @@ public class VanillaNetworkContext<T extends NetworkContext<T>> extends Abstract
 
     @Override
     protected boolean shouldPerformCloseInBackground() {
-        return true;
+        return false;
     }
 
     @NotNull

--- a/src/test/java/net/openhft/chronicle/network/NetworkStatsAdapter.java
+++ b/src/test/java/net/openhft/chronicle/network/NetworkStatsAdapter.java
@@ -1,0 +1,34 @@
+package net.openhft.chronicle.network;
+
+/**
+ * Adapter to make it easier to make inline NetworkStatsListeners
+ *
+ * @param <N> the NetworkContext type
+ */
+public class NetworkStatsAdapter<N extends NetworkContext<N>> implements NetworkStatsListener<N> {
+
+    @Override
+    public void networkContext(N networkContext) {
+    }
+
+    @Override
+    public void onNetworkStats(long writeBps, long readBps, long socketPollCountPerSecond) {
+    }
+
+    @Override
+    public void onHostPort(String hostName, int port) {
+    }
+
+    @Override
+    public void onRoundTripLatency(long nanosecondLatency) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public boolean isClosed() {
+        return false;
+    }
+}

--- a/src/test/java/net/openhft/chronicle/network/VanillaNetworkContextTest.java
+++ b/src/test/java/net/openhft/chronicle/network/VanillaNetworkContextTest.java
@@ -1,21 +1,33 @@
 package net.openhft.chronicle.network;
 
 import net.openhft.chronicle.core.io.BackgroundResourceReleaser;
+import net.openhft.chronicle.threads.Pauser;
+import net.openhft.chronicle.threads.TimingPauser;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertFalse;
 
 public class VanillaNetworkContextTest extends NetworkTestCommon {
 
     @Test
-    public void testClose() {
-        final VanillaNetworkContext v = new VanillaNetworkContext();
-        assertEquals(false, v.isClosed());
-        v.close();
-        assertEquals(true, v.isClosing());
-        BackgroundResourceReleaser.releasePendingResources();
-        assertEquals(true, v.isClosed());
-        v.close();
-        assertEquals(true, v.isClosed());
+    public void networkStatsListenerShouldNotBeClosedOnBackgroundResourceReleaserThread() throws TimeoutException {
+        final VanillaNetworkContext<?> vanillaNetworkContext = new VanillaNetworkContext<>();
+        AtomicReference<Boolean> wasClosedInBackgroundReleaserThread = new AtomicReference<>();
+        vanillaNetworkContext.networkStatsListener(new NetworkStatsAdapter() {
+            @Override
+            public void close() {
+                wasClosedInBackgroundReleaserThread.set(BackgroundResourceReleaser.isOnBackgroundResourceReleaserThread());
+            }
+        });
+        vanillaNetworkContext.close();
+        TimingPauser pauser = Pauser.balanced();
+        while (wasClosedInBackgroundReleaserThread.get() == null) {
+            pauser.pause(5, TimeUnit.SECONDS);
+        }
+        assertFalse(wasClosedInBackgroundReleaserThread.get());
     }
 }


### PR DESCRIPTION
Fixes ChronicleEnterprise/Chronicle-FIX#716

I also removed a test that looked like it was trying to test that close WAS executed in the background, it didn't work though because isClosing() returns true when isClosed() is true.