### PR TITLE
Round-robin which writer gets to write first when calling WritableSubhandlers

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/cluster/handlers/UberHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/cluster/handlers/UberHandler.java
@@ -50,6 +50,9 @@ public final class UberHandler<T extends ClusteredNetworkContext<T>> extends Csp
     @Nullable
     private ConnectionManager<T> connectionChangedNotifier;
 
+    // Used to round-robin which WritableSubHandler gets first chance to write to the buffer
+    private int writerOffset = 0;
+
     @UsedViaReflection
     private UberHandler(@NotNull final WireIn wire) {
         remoteIdentifier = wire.read("remoteIdentifier").int32();
@@ -259,17 +262,22 @@ public final class UberHandler<T extends ClusteredNetworkContext<T>> extends Csp
     @SuppressWarnings("ForLoopReplaceableByForEach")
     protected void onWrite(@NotNull final WireOut outWire) {
         super.onWrite(outWire);
-        for (int i = 0; i < writers.size(); i++)
+        for (int i = 0; i < writers.size(); i++) {
+            int writerIndex = (i + writerOffset) % writers.size();
             try {
                 if (isClosing())
                     return;
-                final WritableSubHandler<T> w = writers.get(i);
+                final WritableSubHandler<T> w = writers.get(writerIndex);
                 if (w != null)
                     w.onWrite(outWire);
             } catch (Exception e) {
                 Jvm.error().on(getClass(), "onWrite:", e);
                 throw Jvm.rethrow(e);
             }
+        }
+        if (!writers.isEmpty()) {
+            writerOffset = (writerOffset + 1) % writers.size(); // protect against overflow
+        }
     }
 
     private void onMessageReceivedOrWritten() {

--- a/src/test/java/net/openhft/chronicle/network/UberHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/network/UberHandlerTest.java
@@ -23,6 +23,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
@@ -42,17 +44,23 @@ public class UberHandlerTest extends NetworkTestCommon {
     private static final int ROUNDS_PER_SIZE_CYCLE = 100;
     private static final int NUM_HANDLERS = 4;
     private static final long RUN_TIME_MS = 5_000;
-    private static final AtomicBoolean running = new AtomicBoolean(false);
-    private static final AtomicInteger stopped = new AtomicInteger(0);
-    private static Map<Long, Integer> countersPerCid;
+    private static final int FIRST_CID = 12345;
+    private static final String TEST_HANDLERS_CSP = "testhandlercsp";
+    private static final AtomicBoolean RUNNING = new AtomicBoolean(false);
+    private static final AtomicInteger STOPPED = new AtomicInteger(0);
+    private static final List<Long> MESSAGES_RECEIVED_CIDS = new ArrayList<>();
+    private static final AtomicInteger SENDERS_INITIALIZED = new AtomicInteger();
+    private static final Map<Long, Integer> COUNTERS_PER_CID = new ConcurrentHashMap<>();
 
     @Before
     public void before() {
         YamlLogging.setAll(false);
         System.setProperty("TcpEventHandler.tcpBufferSize", "131072");
-        countersPerCid = new ConcurrentHashMap<>();
-        running.set(true);
-        stopped.set(0);
+        COUNTERS_PER_CID.clear();
+        RUNNING.set(true);
+        STOPPED.set(0);
+        MESSAGES_RECEIVED_CIDS.clear();
+        SENDERS_INITIALIZED.set(0);
     }
 
     @After
@@ -76,7 +84,7 @@ public class UberHandlerTest extends NetworkTestCommon {
                 if (isConnected) {
                     IntStream.range(0, NUM_HANDLERS).forEach(seq -> {
                         nc.wireOutPublisher().publish(w ->
-                                w.writeDocument(true, d -> sendPingPong(d, 12345 + seq)));
+                                w.writeDocument(true, d -> sendHandler(d, FIRST_CID + seq, new PingPongHandler(false))));
                     });
                 }
             });
@@ -85,7 +93,7 @@ public class UberHandlerTest extends NetworkTestCommon {
             while (System.currentTimeMillis() - startTime < RUN_TIME_MS && !Thread.currentThread().isInterrupted()) {
                 Jvm.pause(100);
             }
-            Jvm.startup().on(PingPongHandler.class, "Test complete, stopping handlers countersPerCid=" + countersPerCid);
+            Jvm.startup().on(PingPongHandler.class, "Test complete, stopping handlers countersPerCid=" + COUNTERS_PER_CID);
             stopAndWaitTillAllHandlersEnd();
             assertTrue(pingPongsAllCompletedAtLeastOneRound());
         }
@@ -98,17 +106,17 @@ public class UberHandlerTest extends NetworkTestCommon {
     }
 
     private void stopAndWaitTillAllHandlersEnd() throws TimeoutException {
-        running.set(false);
+        RUNNING.set(false);
         TimingPauser pauser = Pauser.balanced();
 
         // Wait till both sides of all handlers are stopped
-        while (stopped.get() < NUM_HANDLERS * 2) {
+        while (STOPPED.get() < NUM_HANDLERS * 2) {
             pauser.pause(10, TimeUnit.SECONDS);
         }
     }
 
     private boolean pingPongsAllCompletedAtLeastOneRound() {
-        return countersPerCid.size() == NUM_HANDLERS && countersPerCid.values().stream().allMatch(val -> val > 0);
+        return COUNTERS_PER_CID.size() == NUM_HANDLERS && COUNTERS_PER_CID.values().stream().allMatch(val -> val > 0);
     }
 
     @Test
@@ -182,10 +190,70 @@ public class UberHandlerTest extends NetworkTestCommon {
         }
     }
 
-    private void sendPingPong(WireOut wireOut, int cid) {
-        wireOut.writeEventName(CoreFields.csp).text("pingpong")
+    @Test
+    public void testBusyWritingHandlersAreCalledFirstInRoundRobin() throws IOException, TimeoutException {
+        TCPRegistry.createServerSocketChannelFor("initiator", "acceptor");
+        HostDetails initiatorHost = new HostDetails().hostId(2).connectUri("initiator");
+        HostDetails acceptorHost = new HostDetails().hostId(1).connectUri("acceptor");
+
+        try (MyClusterContext acceptorCtx = clusterContext(acceptorHost, initiatorHost);
+             MyClusterContext initiatorCtx = clusterContext(initiatorHost, acceptorHost)) {
+
+            acceptorCtx.cluster().start(acceptorHost.hostId());
+            initiatorCtx.cluster().start(initiatorHost.hostId());
+
+            initiatorCtx.connectionManager(acceptorHost.hostId()).addListener((nc, isConnected) -> {
+                if (isConnected) {
+                    IntStream.range(0, NUM_HANDLERS).forEach(seq -> {
+                        nc.wireOutPublisher().publish(w ->
+                                w.writeDocument(true, d -> sendHandler(d, FIRST_CID + seq, new Receiver())));
+                    });
+                }
+            });
+
+            long startTime = System.currentTimeMillis();
+            while (System.currentTimeMillis() - startTime < RUN_TIME_MS && !Thread.currentThread().isInterrupted()) {
+                Jvm.pause(100);
+            }
+            Jvm.startup().on(UberHandlerTest.class, String.format("Test complete, stopping handlers messages received=%,d", MESSAGES_RECEIVED_CIDS.size()));
+            stopAndWaitTillAllHandlersEnd();
+            assertTrue(messagesWereReceivedInRoundRobinOrder());
+        }
+    }
+
+    /**
+     * Tests that multiple writers write first in a round-robin fashion
+     * <p>
+     * e.g. for 4 handlers:
+     * 1, 2, 3, 4
+     * 4, 1, 2, 3
+     * 3, 4, 1, 2
+     * 2, 3, 4, 1
+     * ...
+     * <p>
+     * This is fairer than e.g.
+     * 1, 2, 3, 4
+     * 1, 3, 4, 4
+     * ...
+     * where 1 gets to fill the buffer every time
+     */
+    private boolean messagesWereReceivedInRoundRobinOrder() {
+        long offset = MESSAGES_RECEIVED_CIDS.get(0) - FIRST_CID;
+        for (int i = 0; i < MESSAGES_RECEIVED_CIDS.size(); i++) {
+            long expectedCID = FIRST_CID + ((i + offset) % NUM_HANDLERS);
+            if (expectedCID != MESSAGES_RECEIVED_CIDS.get(i)) {
+                return false;
+            }
+            if (i % NUM_HANDLERS == NUM_HANDLERS - 1)
+                offset++;
+        }
+        return true;
+    }
+
+    private void sendHandler(WireOut wireOut, int cid, Marshallable handler) {
+        wireOut.writeEventName(CoreFields.csp).text(TEST_HANDLERS_CSP)
                 .writeEventName(CoreFields.cid).int64(cid)
-                .writeEventName(CoreFields.handler).typedMarshallable(new PingPongHandler(false));
+                .writeEventName(CoreFields.handler).typedMarshallable(handler);
     }
 
     @NotNull
@@ -248,14 +316,76 @@ public class UberHandlerTest extends NetworkTestCommon {
         }
     }
 
-    static class PingPongHandler extends AbstractSubHandler<MyClusteredNetworkContext> implements
+    static class Sender extends AbstractCompleteFlaggingHandler
+            implements WritableSubHandler<MyClusteredNetworkContext>, Marshallable {
+
+        public Sender() {
+        }
+
+        @Override
+        public void onRead(@NotNull WireIn inWire, @NotNull WireOut outWire) {
+            throw new AssertionError("The Sender should never receive any messages, the test depends that it is solely a writer");
+        }
+
+        @Override
+        public void onInitialize(WireOut outWire) throws RejectedExecutionException {
+            Jvm.startup().on(Sender.class, "Initializing (cid=" + cid() + ")");
+            SENDERS_INITIALIZED.incrementAndGet();
+        }
+
+        @Override
+        public void onWrite(WireOut outWire) {
+            if (!RUNNING.get()) {
+                flagComplete();
+                return;
+            }
+
+            if (SENDERS_INITIALIZED.get() != NUM_HANDLERS) {
+                return;
+            }
+
+            try (final DocumentContext dc = outWire.writingDocument(true)) {
+                dc.wire().write(CoreFields.cid).int64(cid());
+            }
+            try (final DocumentContext documentContext = outWire.writingDocument()) {
+                documentContext.wire().write("hello").text("world");
+            }
+        }
+    }
+
+    static class Receiver extends AbstractCompleteFlaggingHandler
+            implements WritableSubHandler<MyClusteredNetworkContext>, Marshallable {
+
+        @Override
+        public void onRead(@NotNull WireIn inWire, @NotNull WireOut outWire) {
+            MESSAGES_RECEIVED_CIDS.add(cid());
+        }
+
+        @Override
+        public void onInitialize(WireOut outWire) throws RejectedExecutionException {
+            Jvm.startup().on(Receiver.class, "Initializing (cid=" + cid() + ")");
+            outWire.writeDocument(true, d ->
+                    d.writeEventName(CoreFields.csp).text(TEST_HANDLERS_CSP)
+                            .writeEventName(CoreFields.cid).int64(cid())
+                            .writeEventName(CoreFields.handler).typedMarshallable(new Sender())
+            );
+        }
+
+        @Override
+        public void onWrite(WireOut outWire) {
+            if (!RUNNING.get()) {
+                flagComplete();
+            }
+        }
+    }
+
+    static class PingPongHandler extends AbstractCompleteFlaggingHandler implements
             Marshallable, WritableSubHandler<MyClusteredNetworkContext> {
 
         private static final int LOGGING_INTERVAL = 50;
 
         private boolean initiator;
         private boolean initiated = false;
-        private boolean flaggedComplete = false;
         private int round = 0;
 
         public PingPongHandler(boolean initiator) {
@@ -268,7 +398,7 @@ public class UberHandlerTest extends NetworkTestCommon {
             // Send back the handler for the other side
             if (!initiator) {
                 outWire.writeDocument(true, d ->
-                        d.writeEventName(CoreFields.csp).text("pingpong")
+                        d.writeEventName(CoreFields.csp).text(TEST_HANDLERS_CSP)
                                 .writeEventName(CoreFields.cid).int64(cid())
                                 .writeEventName(CoreFields.handler).typedMarshallable(new PingPongHandler(!initiator))
                 );
@@ -278,7 +408,7 @@ public class UberHandlerTest extends NetworkTestCommon {
         @Override
         public void onRead(@NotNull WireIn inWire, @NotNull WireOut outWire) {
             throwExceptionIfClosed();
-            if (!running.get()) {
+            if (!RUNNING.get()) {
                 flagComplete();
                 return;
             }
@@ -291,7 +421,7 @@ public class UberHandlerTest extends NetworkTestCommon {
 
                 // Keep track of what round we're up to
                 if (initiator) {
-                    countersPerCid.put(cid(), round);
+                    COUNTERS_PER_CID.put(cid(), round);
                 }
 
                 round++;
@@ -325,7 +455,7 @@ public class UberHandlerTest extends NetworkTestCommon {
         @Override
         public void onWrite(WireOut outWire) {
             throwExceptionIfClosed();
-            if (!running.get()) {
+            if (!RUNNING.get()) {
                 flagComplete();
                 return;
             }
@@ -349,16 +479,24 @@ public class UberHandlerTest extends NetworkTestCommon {
             initiator = wire.read("initiator").bool();
         }
 
-        private void flagComplete() {
-            if (!flaggedComplete) {
-                stopped.incrementAndGet();
-                flaggedComplete = true;
-            }
-        }
-
         private void sendPingPongCid(WireOut outWire) {
             try (final DocumentContext dc = outWire.writingDocument(true)) {
                 dc.wire().write(CoreFields.cid).int64(cid());
+            }
+        }
+    }
+
+    /**
+     * Just a common way of knowing when all handlers have stopped writing
+     */
+    abstract static class AbstractCompleteFlaggingHandler extends AbstractSubHandler<MyClusteredNetworkContext> {
+        private boolean flaggedComplete = false;
+
+        protected void flagComplete() {
+            if (!flaggedComplete) {
+                STOPPED.incrementAndGet();
+                flaggedComplete = true;
+                Jvm.startup().on(getClass(), String.format("Handler with cid=%s finished", cid()));
             }
         }
     }


### PR DESCRIPTION
Part of the fix for ChronicleEnterprise/Chronicle-Queue-Enterprise#255