### PR TITLE
Remove WireTcpHandler#recreateWire

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/WireTcpHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/WireTcpHandler.java
@@ -43,7 +43,6 @@ public abstract class WireTcpHandler<T extends NetworkContext<T>>
     protected WireType wireType;
     long lastWritePosition = 0;
     private Wire inWire;
-    private boolean recreateWire;
     private WireOutPublisher publisher;
     private T nc;
     private boolean isAcceptor;
@@ -218,22 +217,13 @@ public abstract class WireTcpHandler<T extends NetworkContext<T>>
     }
 
     protected void checkWires(final Bytes<?> in, Bytes<?> out, @NotNull final WireType wireType) {
-        if (recreateWire) {
-            recreateWire = false;
-            initialiseInWire(wireType, in);
-            initialiseOutWire(out, wireType);
-            return;
-        }
-
         if (inWire == null) {
             initialiseInWire(wireType, in);
-            recreateWire = false;
         }
 
         assert inWire.startUse();
         if (inWire.bytes() != in) {
             initialiseInWire(wireType, in);
-            recreateWire = false;
         }
         assert inWire.endUse();
 
@@ -245,7 +235,6 @@ public abstract class WireTcpHandler<T extends NetworkContext<T>>
         }
         if (replace) {
             initialiseOutWire(out, wireType);
-            recreateWire = false;
         }
     }
 


### PR DESCRIPTION
`recreateWire` was first added on 12/3/2015 (in commit ab36c4ee3192643cd4a321e9d8b06d6b34ab35df) then the setter for it was removed on 21/5/2015 (in commit b63649ac0532d2490e22ac5eef997caf92a3c050)

I suspect it hasn't been `true` since 21/5/2015, so should be OK to remove the branch?