### PR TITLE
Feature/perf experiments

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,7 +59,7 @@ final String desc = "host.port";
 TCPRegistry.createServerSocketChannelFor(desc);
 
 // We use an event loop rather than lots of threads
-EventLoop eg = new EventGroup(true);
+EventLoop eg = EventGroup.builder().build();
 eg.start();
 ----
 

--- a/jmh/src/main/java/net/openhft/chronicle/network/ChanelHubTest.java
+++ b/jmh/src/main/java/net/openhft/chronicle/network/ChanelHubTest.java
@@ -96,7 +96,7 @@ public class ChanelHubTest {
     public void setUp() throws IOException {
         String desc = "host.port";
         TCPRegistry.createServerSocketChannelFor(desc);
-        eg = new EventGroup(true);
+        eg = EventGroup.builder().build();
         eg.start();
         expectedMessage = "<my message>";
         createServer(desc, eg);

--- a/jmh/src/main/java/net/openhft/chronicle/network/VerySimpleClient.java
+++ b/jmh/src/main/java/net/openhft/chronicle/network/VerySimpleClient.java
@@ -100,7 +100,7 @@ public class VerySimpleClient {
     public void setUp() throws Exception {
         String desc = "host.port";
         TCPRegistry.createServerSocketChannelFor(desc);
-        eg = new EventGroup(true);
+        eg = EventGroup.builder().build();
         eg.start();
         expectedMessage = "<my message>";
         createServer(desc, eg);

--- a/src/test/java/net/openhft/chronicle/network/ssl/NonClusteredSslIntegrationTest.java
+++ b/src/test/java/net/openhft/chronicle/network/ssl/NonClusteredSslIntegrationTest.java
@@ -48,8 +48,8 @@ import static org.junit.Assert.assertTrue;
 public final class NonClusteredSslIntegrationTest extends NetworkTestCommon {
 
     private static final boolean DEBUG = Jvm.getBoolean("NonClusteredSslIntegrationTest.debug");
-    private final EventGroup client = new EventGroup(true, Pauser.millis(1), false, "client");
-    private final EventGroup server = new EventGroup(true, Pauser.millis(1), false, "server");
+    private final EventGroup client = EventGroup.builder().withPauser(Pauser.millis(1)).withName("client").build();
+    private final EventGroup server = EventGroup.builder().withPauser(Pauser.millis(1)).withName("server").build();
     private final CountingTcpHandler clientAcceptor = new CountingTcpHandler("client-acceptor");
     private final CountingTcpHandler serverAcceptor = new CountingTcpHandler("server-acceptor");
     private final CountingTcpHandler clientInitiator = new CountingTcpHandler("client-initiator");

--- a/src/test/java/net/openhft/performance/tests/network/BinaryTestBufferSize.java
+++ b/src/test/java/net/openhft/performance/tests/network/BinaryTestBufferSize.java
@@ -67,7 +67,7 @@ public class BinaryTestBufferSize {
     @Before
     public void setUp() throws IOException {
         TCPRegistry.createServerSocketChannelFor(desc);
-        eg = new EventGroup(true);
+        eg = EventGroup.builder().build();
         eg.start();
         createServer(desc, eg);
     }

--- a/src/test/java/net/openhft/performance/tests/network/PingPongWithMains.java
+++ b/src/test/java/net/openhft/performance/tests/network/PingPongWithMains.java
@@ -131,7 +131,7 @@ public class PingPongWithMains {
     }
 
     public void testServer() throws IOException {
-        @NotNull EventLoop eg = new EventGroup(true, Pauser.busy(), true);
+        @NotNull EventLoop eg = EventGroup.builder().withPauser(Pauser.busy()).withBinding("any").build();
 
         eg.start();
         TCPRegistry.createServerSocketChannelFor(serverHostPort);

--- a/src/test/java/net/openhft/performance/tests/network/SimpleServerAndClientTest.java
+++ b/src/test/java/net/openhft/performance/tests/network/SimpleServerAndClientTest.java
@@ -67,7 +67,7 @@ public class SimpleServerAndClientTest extends NetworkTestCommon {
 
             Bytes<ByteBuffer> bytes = Bytes.elasticByteBuffer();
             // we use an event loop rather than lots of threads
-            try (@NotNull EventLoop eg = new EventGroup(true)) {
+            try (@NotNull EventLoop eg = EventGroup.builder().build()) {
                 eg.start();
 
                 // an example message that we are going to send from the server to the client and back

--- a/src/test/java/net/openhft/performance/tests/network/SimpleServerAndClientTest.java
+++ b/src/test/java/net/openhft/performance/tests/network/SimpleServerAndClientTest.java
@@ -18,7 +18,6 @@
 package net.openhft.performance.tests.network;
 
 import net.openhft.chronicle.bytes.Bytes;
-import net.openhft.chronicle.core.io.AbstractReferenceCounted;
 import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.core.threads.HandlerPriority;
 import net.openhft.chronicle.network.AcceptorEventHandler;
@@ -52,11 +51,6 @@ public class SimpleServerAndClientTest extends NetworkTestCommon {
     @Ignore("https://github.com/OpenHFT/Chronicle-Network/issues/133")
     @Test
     public void test() throws IOException {
-//        assert TCP_USE_PADDING;
-        // TODO FIX
-        AbstractReferenceCounted.disableReferenceTracing();
-        expectException("Reference tracing disabled");
-
         YamlLogging.setAll(true);
 
         for (; ; ) {

--- a/src/test/java/net/openhft/performance/tests/network/TimedEchoHandler.java
+++ b/src/test/java/net/openhft/performance/tests/network/TimedEchoHandler.java
@@ -39,7 +39,7 @@ class TimedEchoHandler<T extends NetworkContext<T>>
     }
 
     public static <T extends NetworkContext<T>> void main(String[] args) throws IOException {
-        @NotNull EventLoop eg = new EventGroup(false);
+        @NotNull EventLoop eg = EventGroup.builder().withDaemon(false).build();
         eg.start();
         @NotNull AcceptorEventHandler<T> eah = new AcceptorEventHandler<>("*:" + EchoClientMain.PORT,
                 LegacyHanderFactory.legacyTcpEventHandlerFactory(TimedEchoHandler::new),

--- a/src/test/java/net/openhft/performance/tests/network/VerySimpleClientTest.java
+++ b/src/test/java/net/openhft/performance/tests/network/VerySimpleClientTest.java
@@ -87,7 +87,7 @@ public class VerySimpleClientTest extends NetworkTestCommon {
 
     @Override
     protected void preAfter() {
-        Closeable.closeQuietly(sc, eg);
+        Closeable.closeQuietly(sc, eg, client);
         TcpChannelHub.closeAllHubs();
         inWire.bytes().releaseLast();
         outWire.bytes().releaseLast();
@@ -95,10 +95,6 @@ public class VerySimpleClientTest extends NetworkTestCommon {
 
     @Test
     public void test() throws IOException {
-        expectException("Reference tracing disabled");
-// TODO FIX
-        AbstractReferenceCounted.disableReferenceTracing();
-
         // create the message to send§
         final long tid = 0;
         outWire.clear();

--- a/src/test/java/net/openhft/performance/tests/network/VerySimpleClientTest.java
+++ b/src/test/java/net/openhft/performance/tests/network/VerySimpleClientTest.java
@@ -77,7 +77,7 @@ public class VerySimpleClientTest extends NetworkTestCommon {
     public void setUp() throws IOException {
         @NotNull String desc = "host.port";
         TCPRegistry.createServerSocketChannelFor(desc);
-        eg = new EventGroup(true);
+        eg = EventGroup.builder().build();
         eg.start();
         expectedMessage = "<my message>";
         createServer(desc, eg);

--- a/src/test/java/net/openhft/performance/tests/network/WireTcpHandlerTest.java
+++ b/src/test/java/net/openhft/performance/tests/network/WireTcpHandlerTest.java
@@ -143,7 +143,7 @@ public class WireTcpHandlerTest extends NetworkTestCommon {
 // TODO FIX
         AbstractReferenceCounted.disableReferenceTracing();
 
-        try (@NotNull EventLoop eg = new EventGroup(true)) {
+        try (@NotNull EventLoop eg = EventGroup.builder().build()) {
             eg.start();
             TCPRegistry.createServerSocketChannelFor(desc);
             @NotNull AcceptorEventHandler eah = new AcceptorEventHandler(desc,

--- a/src/test/java/net/openhft/performance/tests/network/WireTcpHandlerTest.java
+++ b/src/test/java/net/openhft/performance/tests/network/WireTcpHandlerTest.java
@@ -18,7 +18,6 @@
 package net.openhft.performance.tests.network;
 
 import net.openhft.chronicle.bytes.Bytes;
-import net.openhft.chronicle.core.io.AbstractReferenceCounted;
 import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.network.*;
 import net.openhft.chronicle.network.connection.TcpChannelHub;
@@ -139,9 +138,6 @@ public class WireTcpHandlerTest extends NetworkTestCommon {
     public void testProcess() throws IOException {
         boolean logging = YamlLogging.showClientReads();
         YamlLogging.setAll(false);
-        expectException("Reference tracing disabled");
-// TODO FIX
-        AbstractReferenceCounted.disableReferenceTracing();
 
         try (@NotNull EventLoop eg = EventGroup.builder().build()) {
             eg.start();

--- a/src/test/java/net/openhft/performance/tests/vanilla/tcp/EchoServer2Main.java
+++ b/src/test/java/net/openhft/performance/tests/vanilla/tcp/EchoServer2Main.java
@@ -3,7 +3,6 @@ package net.openhft.performance.tests.vanilla.tcp;
 import net.openhft.affinity.Affinity;
 import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.network.AcceptorEventHandler;
-import net.openhft.chronicle.network.NetworkContext;
 import net.openhft.chronicle.network.TcpEventHandler;
 import net.openhft.chronicle.network.VanillaNetworkContext;
 import net.openhft.chronicle.threads.EventGroup;
@@ -17,7 +16,7 @@ public class EchoServer2Main {
     public static <T extends VanillaNetworkContext<T>> void main(String[] args) throws IOException {
         System.setProperty("pauser.minProcessors", "1");
         Affinity.acquireCore();
-        @NotNull EventLoop eg = new EventGroup(false, Pauser.busy(), true);
+        @NotNull EventLoop eg = EventGroup.builder().withDaemon(false).withPauser(Pauser.busy()).withBinding("any").build();
         eg.start();
 
         @NotNull AcceptorEventHandler<T> eah = new AcceptorEventHandler<T>("*:" + EchoClientMain.PORT,


### PR DESCRIPTION
Tidy tests, de-deprecate calls to `new EventGroup` and add some features to PingPongWithMains to allow overriding of params, plus the ability to allocate buffers on another NUMA node in response to customer query.
