### PR TITLE
System.out.println(...) -> Jvm.startup().on(...)

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/TCPRegistry.java
+++ b/src/main/java/net/openhft/chronicle/network/TCPRegistry.java
@@ -229,7 +229,7 @@ public enum TCPRegistry {
     }
 
     public static void dumpAllSocketChannels() {
-        lookupTable().forEach((s, inetSocketAddress) -> System.out.println(s + ": " + inetSocketAddress.toString()));
+        lookupTable().forEach((s, inetSocketAddress) -> Jvm.startup().on(TCPRegistry.class, s + ": " + inetSocketAddress.toString()));
     }
 
     public static void assertAllServersStopped(final long timeout, final TimeUnit unit) {

--- a/src/main/java/net/openhft/chronicle/network/TcpEventHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/TcpEventHandler.java
@@ -74,7 +74,7 @@ public class TcpEventHandler<T extends NetworkContext<T>>
     public static boolean DISABLE_TCP_NODELAY = Jvm.getBoolean("disable.tcp_nodelay");
 
     static {
-        if (DISABLE_TCP_NODELAY) System.out.println("tcpNoDelay disabled");
+        if (DISABLE_TCP_NODELAY) Jvm.startup().on(TcpEventHandler.class, "tcpNoDelay disabled");
     }
 
     private TcpEventHandler.SocketReader reader = new DefaultSocketReader();
@@ -334,7 +334,7 @@ public class TcpEventHandler<T extends NetworkContext<T>>
     }
 
     public void warmUp() {
-        // System.out.println(TcpEventHandler.class.getSimpleName() + " - Warming up...");
+        Jvm.debug().on(TcpEventHandler.class, "Warming up...");
         final int runs = 12000;
         long beginNs = System.nanoTime();
         for (int i = 0; i < runs; i++) {
@@ -343,7 +343,7 @@ public class TcpEventHandler<T extends NetworkContext<T>>
             clearBuffer();
         }
         long elapsedNs = System.nanoTime() - beginNs;
-        // System.out.println(TcpEventHandler.class.getSimpleName() + " - ... warmed up - took " + (elapsedNs / runs / 1e3) + " us avg");
+        Jvm.debug().on(TcpEventHandler.class, "... warmed up - took " + (elapsedNs / runs / 1e3) + " us avg");
     }
 
     private void checkBufSize(final int bufSize, final String name) {

--- a/src/main/java/net/openhft/chronicle/network/WireTcpHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/WireTcpHandler.java
@@ -49,7 +49,7 @@ public abstract class WireTcpHandler<T extends NetworkContext<T>>
 
     private static void logYaml(@NotNull final DocumentContext dc) {
         try {
-            System.out.println(
+            Jvm.startup().on(WireTcpHandler.class,
                     "Server Reads:\n" +
                             Wires.fromSizePrefixedBlobs(dc));
 
@@ -62,7 +62,7 @@ public abstract class WireTcpHandler<T extends NetworkContext<T>>
     private static void logYaml(@NotNull final WireOut outWire) {
         if (YamlLogging.showServerWrites())
             try {
-                System.out.println(
+                Jvm.startup().on(WireTcpHandler.class,
                         "Server Sends:\n" +
                                 Wires.fromSizePrefixedBlobs((Wire) outWire));
 
@@ -127,9 +127,9 @@ public abstract class WireTcpHandler<T extends NetworkContext<T>>
             if (YamlLogging.showServerWrites() && remaining >= 4) {
                 int length = Wires.lengthOf(bytes.peekVolatileInt());
                 if (length <= remaining)
-                    System.out.println("sending from WTH: " + Wires.fromSizePrefixedBlobs(outWire));
+                    Jvm.startup().on(WireTcpHandler.class, "sending from WTH: " + Wires.fromSizePrefixedBlobs(outWire));
                 else
-                    System.out.println("send remaining from WTH: " + remaining);
+                    Jvm.startup().on(WireTcpHandler.class, "send remaining from WTH: " + remaining);
             }
             onWrite(outWire);
         }

--- a/src/main/java/net/openhft/chronicle/network/connection/TcpChannelHub.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/TcpChannelHub.java
@@ -226,18 +226,18 @@ public final class TcpChannelHub extends AbstractCloseable {
         hubs.clear();
     }
 
-     static void logToStandardOutMessageReceived(@NotNull final Wire wire) {
-         @NotNull final Bytes<?> bytes = wire.bytes();
+    static void logToStandardOutMessageReceived(@NotNull final Wire wire) {
+        @NotNull final Bytes<?> bytes = wire.bytes();
 
-         if (!YamlLogging.showClientReads())
-             return;
+        if (!YamlLogging.showClientReads())
+            return;
 
-         final long position = bytes.writePosition();
-         final long limit = bytes.writeLimit();
-         try {
-             try {
+        final long position = bytes.writePosition();
+        final long limit = bytes.writeLimit();
+        try {
+            try {
 
-                System.out.println(
+                Jvm.startup().on(TcpChannelHub.class,
                         "receives:\n" +
                                 Wires.fromSizePrefixedBlobs(wire));
                 YamlLogging.title = "";
@@ -260,7 +260,7 @@ public final class TcpChannelHub extends AbstractCloseable {
         try {
             try {
 
-                System.out.println(
+                Jvm.startup().on(TcpChannelHub.class,
                         "\nreceives IN ERROR:\n" +
                                 Wires.fromSizePrefixedBlobs(wire));
                 YamlLogging.title = "";
@@ -654,7 +654,7 @@ public final class TcpChannelHub extends AbstractCloseable {
     private void writeSocket1(@NotNull final WireOut outWire, @Nullable final ChronicleSocketChannel clientChannel) throws IOException {
 
         if (YamlLogging.showClientWrites())
-            System.out.println("sending from TCH: " + Wires.fromSizePrefixedBlobs((Wire) outWire));
+            Jvm.startup().on(TcpChannelHub.class, "sending from TCH: " + Wires.fromSizePrefixedBlobs((Wire) outWire));
 
         if (clientChannel == null) {
             Jvm.debug().on(TcpChannelHub.class,

--- a/src/main/java/net/openhft/chronicle/network/tcp/ChronicleSocketChannelFactory.java
+++ b/src/main/java/net/openhft/chronicle/network/tcp/ChronicleSocketChannelFactory.java
@@ -15,7 +15,7 @@ public enum ChronicleSocketChannelFactory {
 
     private static boolean isFastJava8IO() {
         boolean fastJava8IO = Jvm.getBoolean("fastJava8IO") && !Jvm.isJava9Plus() && OS.isLinux();
-        if (fastJava8IO) System.out.println("FastJava8IO: enabled");
+        if (fastJava8IO) Jvm.startup().on(ChronicleSocketChannelFactory.class, "FastJava8IO: enabled");
         return fastJava8IO;
     }
 


### PR DESCRIPTION
When a client was trying to debug an issue, he couldn't put the System.out messages in context with the logged messages, presumably they go to different places in their setup. I think it's better to always use the logger.

It also has the benefit of showing where the messages are coming from.