### PR TITLE
Make RejectedHandlerException handlers log warnings consistently

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=OpenHFT_Chronicle-Network
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=OpenHFT_Chronicle-Network -Psonar

--- a/src/main/java/net/openhft/chronicle/network/cluster/handlers/UberHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/cluster/handlers/UberHandler.java
@@ -209,7 +209,7 @@ public final class UberHandler<T extends ClusteredNetworkContext<T>> extends Csp
                     Jvm.warn().on(getClass(), "EventGroup shutdown", e);
                     removeHandler(handler);
                 } catch (RejectedHandlerException ex) {
-                    Jvm.debug().on(getClass(), "Removing rejected handler: " + handler);
+                    Jvm.warn().on(getClass(), "Removing rejected handler: " + handler + ", message=" + ex.getMessage(), ex);
                     removeHandler(handler);
                 }
                 return;
@@ -220,7 +220,7 @@ public final class UberHandler<T extends ClusteredNetworkContext<T>> extends Csp
                 try {
                     handler.onRead(inWire, outWire);
                 } catch (RejectedHandlerException ex) {
-                    Jvm.debug().on(getClass(), "Removing rejected handler: " + handler);
+                    Jvm.warn().on(getClass(), "Removing rejected handler: " + handler + ", message=" + ex.getMessage(), ex);
                     removeHandler(handler);
                 }
             else {

--- a/src/test/java/net/openhft/chronicle/network/UberHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/network/UberHandlerTest.java
@@ -265,6 +265,7 @@ public class UberHandlerTest extends NetworkTestCommon {
                     // This handler should reject in onRead
                     nc.wireOutPublisher().publish(w ->
                             w.writeDocument(true, d -> sendHandler(d, FIRST_CID + 1, new RejectingOnReadHandler())));
+                    expectException("Rejected in onRead");
                     nc.wireOutPublisher().publish(w ->
                             w.writeDocument(false, d -> sendMessageToHandler(d, FIRST_CID + 1)));
                 }
@@ -289,7 +290,7 @@ public class UberHandlerTest extends NetworkTestCommon {
 
         @Override
         public void onInitialize(WireOut outWire) throws RejectedExecutionException {
-            throw new RejectedExecutionException("Rejected in onInitialize");
+            throw new RejectedHandlerException("Rejected in onInitialize");
         }
 
         @Override


### PR DESCRIPTION
I imagine this will break a few things as it flushes through. Then again it doesn't seem to be used much so maybe it won't be so bad.