### PR TITLE
Publish test jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,13 @@
                         </manifest>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
 
             </plugin>
             <plugin>
@@ -285,6 +292,20 @@
                     <execution>
                         <goals>
                             <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                            <goal>test-jar</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
This is just so we can make the uber-jar containing all the benchmarks for client. You could argue that benchmarks should be in a separately released artifact to avoid the need for publishing a test jar and I would agree, but that's probably a pattern we want to implement across all projects, and this is the easiest path forward.