### PR TITLE
Implement logic to respect JVM DNS caching parameters when caching InetSocketAddresses

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/TCPRegistry.java
+++ b/src/main/java/net/openhft/chronicle/network/TCPRegistry.java
@@ -22,6 +22,7 @@ import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.core.pool.ClassAliasPool;
 import net.openhft.chronicle.network.api.NetworkStats;
 import net.openhft.chronicle.network.connection.FatalFailureConnectionStrategy;
+import net.openhft.chronicle.network.internal.AddressCache;
 import net.openhft.chronicle.network.internal.lookuptable.FileBasedHostnamePortLookupTable;
 import net.openhft.chronicle.network.internal.lookuptable.ProcessLocalHostnamePortLookupTable;
 import net.openhft.chronicle.network.tcp.ChronicleServerSocketChannel;
@@ -55,6 +56,7 @@ public enum TCPRegistry {
     public static final String TCP_REGISTRY_LOOKUP_TABLE_IMPLEMENTATION_PROPERTY = "chronicle.tcpRegistry.lookupTableImplementation";
     static HostnamePortLookupTable lookupTable;
     static final Map<String, ChronicleServerSocketChannel> DESC_TO_SERVER_SOCKET_CHANNEL_MAP = new ConcurrentSkipListMap<>();
+    private static final AddressCache ADDRESS_CACHE = new AddressCache();
 
     static {
         ClassAliasPool.CLASS_ALIASES.addAlias(
@@ -85,6 +87,7 @@ public enum TCPRegistry {
         Closeable.closeQuietly(lookupTable);
         lookupTable = null;
         DESC_TO_SERVER_SOCKET_CHANNEL_MAP.clear();
+        ADDRESS_CACHE.clear();
         Jvm.pause(50);
     }
 
@@ -178,6 +181,9 @@ public enum TCPRegistry {
         InetSocketAddress address = lookupTable().lookup(description);
         if (address != null)
             return address;
+        address = ADDRESS_CACHE.lookup(description);
+        if (address != null)
+            return address;
         String property = System.getProperty(description);
         if (property != null) {
             @NotNull String[] parts = property.split(":", 2);
@@ -211,13 +217,12 @@ public enum TCPRegistry {
         if (port <= 0 || port >= 65536)
             throw new IllegalArgumentException("Invalid port " + port);
 
-        @NotNull InetSocketAddress address = createInetSocketAddress(hostname, port);
-        lookupTable().put(description, address);
-        return address;
+        ADDRESS_CACHE.add(description, hostname, port);
+        return ADDRESS_CACHE.lookup(description);
     }
 
     @NotNull
-    private static InetSocketAddress createInetSocketAddress(@NotNull String hostname, int port) {
+    public static InetSocketAddress createInetSocketAddress(@NotNull String hostname, int port) {
         return hostname.isEmpty() || hostname.equals("*") ? new InetSocketAddress(port) : new InetSocketAddress(hostname, port);
     }
 

--- a/src/main/java/net/openhft/chronicle/network/connection/SocketAddressSupplier.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/SocketAddressSupplier.java
@@ -167,18 +167,16 @@ public class SocketAddressSupplier implements Supplier<SocketAddress> {
 
     public static class RemoteAddressSupplier implements Supplier<SocketAddress> {
 
-        private final InetSocketAddress remoteAddress;
         @NotNull
         private final String description;
 
         public RemoteAddressSupplier(@NotNull String description) {
             this.description = description;
-            remoteAddress = TCPRegistry.lookup(description);
         }
 
         @Override
         public InetSocketAddress get() {
-            return remoteAddress;
+            return TCPRegistry.lookup(description);
         }
 
         @NotNull

--- a/src/main/java/net/openhft/chronicle/network/internal/AddressCache.java
+++ b/src/main/java/net/openhft/chronicle/network/internal/AddressCache.java
@@ -1,0 +1,114 @@
+package net.openhft.chronicle.network.internal;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.net.InetSocketAddress;
+import java.security.Security;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static net.openhft.chronicle.network.TCPRegistry.createInetSocketAddress;
+
+/**
+ * A cache of {@link InetSocketAddress}es.
+ * <p>
+ * This will prevent the creation of a new {@link InetSocketAddress} every time, but will configure expiry
+ * consistent with the JVM <em>networkaddress.cache.ttl</em> setting.
+ * <p>
+ * e.g. if <em>networkaddress.cache.ttl</em> is set to:
+ * <dl>
+ *   <dt>0</dt>
+ *      <dd>caching will be disabled altogether, this cache will just remember e.g. description to system property mappings</dd>
+ *   <dt>30</dt>
+ *      <dd>InetSocketAddresses will be cached for 30s after their first lookup</dd>
+ *   <dt>any negative value</dt>
+ *      <dd>InetSocketAddresses will be cached forever</dd>
+ * </dl>
+ * <p>
+ * Note: This will default to caching addresses forever when no value is specified for <em>networkaddress.cache.ttl</em>,
+ * as per the documentation, that default may differ from the JVM default when no security manager is installed.
+ */
+public class AddressCache {
+
+    private static final String NETWORK_ADDRESS_CACHE_TTL = "networkaddress.cache.ttl";
+    private static final int NEVER_EXPIRE = -1;
+
+    private final Map<String, CacheEntry> cachedAddresses;
+
+    public AddressCache() {
+        cachedAddresses = new ConcurrentHashMap<>();
+    }
+
+    public InetSocketAddress lookup(String description) {
+        final CacheEntry cacheEntry = cachedAddresses.get(description);
+        return cacheEntry != null ? cacheEntry.address() : null;
+    }
+
+    public void add(String description, String hostname, int port) {
+        cachedAddresses.put(description, new CacheEntry(hostname, port));
+    }
+
+    public void clear() {
+        cachedAddresses.clear();
+    }
+
+    private static final class CacheEntry {
+        @NotNull
+        private final String hostname;
+        private final int port;
+        private InetSocketAddress inetSocketAddress;
+        private long expiryTime;
+
+        public CacheEntry(@NotNull String hostname, int port) {
+            this.hostname = hostname;
+            this.port = port;
+        }
+
+        /**
+         * Get the {@link InetSocketAddress} for this entry, creating a new one if necessary
+         * <p>
+         * Note: it is important this method stays synchronized, to prevent unnecessary InetSocketAddress creation
+         * but also to ensure any updates to the fields are visible to all threads.
+         *
+         * @return The {@link InetSocketAddress}
+         */
+        public synchronized InetSocketAddress address() {
+            if (isCachingEnabled()) {
+                if (inetSocketAddress == null || (expiryTime >= 0 && System.currentTimeMillis() > expiryTime)) {
+                    inetSocketAddress = createInetSocketAddress(hostname, port);
+                    expiryTime = calculateExpiryTime();
+                }
+                return inetSocketAddress;
+            } else {
+                return createInetSocketAddress(hostname, port);
+            }
+        }
+
+        /**
+         * Calculate the expiry time for the cache entry using <em>networkaddress.cache.ttl</em>
+         * <p>
+         * See https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html for details
+         *
+         * @return The expiry time in milliseconds since the epoch or -1 to never expire
+         */
+        private long calculateExpiryTime() {
+            final String cacheTTL = Security.getProperty(NETWORK_ADDRESS_CACHE_TTL);
+            if (cacheTTL != null) {
+                final long parsedCacheTTL = Long.parseLong(cacheTTL);
+                return parsedCacheTTL < 0 ? NEVER_EXPIRE : System.currentTimeMillis() + (1_000 * parsedCacheTTL);
+            } else {
+                return NEVER_EXPIRE;
+            }
+        }
+
+        /**
+         * Is INetSocketAddress caching enabled?
+         *
+         * @return true if caching is enabled, false otherwise
+         */
+        private boolean isCachingEnabled() {
+            final String cacheTTL = Security.getProperty(NETWORK_ADDRESS_CACHE_TTL);
+            return cacheTTL == null || Long.parseLong(cacheTTL) != 0;
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/network/internal/AddressCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/network/internal/AddressCacheTest.java
@@ -1,0 +1,77 @@
+package net.openhft.chronicle.network.internal;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+
+import java.net.InetSocketAddress;
+import java.security.Security;
+
+import static org.junit.Assert.*;
+
+public class AddressCacheTest {
+
+    private static final String NETWORK_ADDRESS_CACHE_TTL = "networkaddress.cache.ttl";
+    private static final String DEFAULT_NETWORK_ADDRESS_CACHE_TTL = "-1";
+    private AddressCache addressCache;
+
+    @Before
+    public void setUp() {
+        addressCache = new AddressCache();
+    }
+
+    @Test
+    public void addingEntryWillMakeItAvailableForLookup() {
+        addressCache.add("test-123", "google.com", 123);
+        assertEquals(addressCache.lookup("test-123"), new InetSocketAddress("google.com", 123));
+    }
+
+    @Test
+    public void entriesAreUnavailableUntilAdded() {
+        assertNull(addressCache.lookup("test-123"));
+    }
+
+    @Test
+    public void clearingWillMakeItUnavailableForLookup() {
+        addressCache.add("test-123", "google.com", 123);
+        assertEquals(addressCache.lookup("test-123"), new InetSocketAddress("google.com", 123));
+        addressCache.clear();
+        assertNull(addressCache.lookup("test-123"));
+    }
+
+    @Test
+    public void resolvedAddressesAreCachedWhenCachingIsEnabled() throws Throwable {
+        withNetworkAddressCacheTtl("100", () -> {
+            addressCache.add("test-123", "google.com", 123);
+            InetSocketAddress original = addressCache.lookup("test-123");
+            assertSame(original, addressCache.lookup("test-123"));
+        });
+    }
+
+    @Test
+    public void resolvedAddressesAreCachedWhenCachingForeverIsEnabled() throws Throwable {
+        withNetworkAddressCacheTtl("-1", () -> {
+            addressCache.add("test-123", "google.com", 123);
+            InetSocketAddress original = addressCache.lookup("test-123");
+            assertSame(original, addressCache.lookup("test-123"));
+        });
+    }
+
+    @Test
+    public void resolvedAddressesAreNotCachedWhenCachingIsDisabled() throws Throwable {
+        withNetworkAddressCacheTtl("0", () -> {
+            addressCache.add("test-123", "google.com", 123);
+            InetSocketAddress original = addressCache.lookup("test-123");
+            assertNotSame(original, addressCache.lookup("test-123"));
+        });
+    }
+
+    private void withNetworkAddressCacheTtl(String ttlValue, ThrowingRunnable testCode) throws Throwable {
+        Security.setProperty(NETWORK_ADDRESS_CACHE_TTL, ttlValue);
+        try {
+            testCode.run();
+        } finally {
+            Security.setProperty(NETWORK_ADDRESS_CACHE_TTL, DEFAULT_NETWORK_ADDRESS_CACHE_TTL);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #168

I opted to use the `networkaddress.cache.ttl` JVM setting to configure this, as it will mean with one setting, users can configure Chronicle and the JVM consistently, and the default is to cache forever, just as our default was that.

There is a slight functional change in this. Previously we used to cache even `hostname:port` addresses in the `HostnamePortLookupTable`, now we will just store ones created using e.g. `createServerSocketChannelFor` in there. I think that's more appropriate anyway, one is a cache, the other is a registry and things in the registry shouldn't ever expire.