### PR TITLE
Update the connection reset exception detection

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/TcpEventHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/TcpEventHandler.java
@@ -54,6 +54,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import static java.lang.Math.max;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 import static net.openhft.chronicle.network.connection.TcpChannelHub.TCP_BUFFER;
+import static net.openhft.chronicle.network.internal.SocketExceptionUtil.isAConnectionResetException;
 
 public class TcpEventHandler<T extends NetworkContext<T>>
         extends AbstractCloseable
@@ -475,7 +476,7 @@ public class TcpEventHandler<T extends NetworkContext<T>>
 
         try {
             String message = e.getMessage();
-            if (message != null && message.startsWith("Connection reset by peer")) {
+            if (isAConnectionResetException(e)) {
                 LOG.trace(message, e);
             } else if (message != null && message.startsWith("An existing connection was forcibly closed")) {
                 Jvm.debug().on(getClass(), message);

--- a/src/main/java/net/openhft/chronicle/network/connection/TcpChannelHub.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/TcpChannelHub.java
@@ -55,6 +55,7 @@ import static java.lang.Integer.getInteger;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.*;
 import static net.openhft.chronicle.bytes.Bytes.elasticByteBuffer;
+import static net.openhft.chronicle.network.internal.SocketExceptionUtil.isAConnectionResetException;
 
 /**
  * The TcpChannelHub is used to send your messages to the server and then read the servers response. The TcpChannelHub ensures that each response is
@@ -1353,7 +1354,7 @@ public final class TcpChannelHub extends AbstractCloseable {
                             if (e instanceof ConnectionDroppedException) {
                                 if (debugEnabled)
                                     Jvm.debug().on(TcpChannelHub.class, "reconnecting due to dropped connection " + ((message == null) ? "" : message));
-                            } else if (e instanceof IOException && "Connection reset by peer".equals(message)) {
+                            } else if (e instanceof IOException && isAConnectionResetException((IOException) e)) {
                                 Jvm.warn().on(TcpChannelHub.class, "reconnecting due to \"Connection reset by peer\" " + message);
                             } else {
                                 Jvm.warn().on(TcpChannelHub.class, "reconnecting due to unexpected exception", e);

--- a/src/main/java/net/openhft/chronicle/network/internal/SocketExceptionUtil.java
+++ b/src/main/java/net/openhft/chronicle/network/internal/SocketExceptionUtil.java
@@ -1,0 +1,28 @@
+package net.openhft.chronicle.network.internal;
+
+import java.io.IOException;
+import java.net.SocketException;
+
+public final class SocketExceptionUtil {
+
+    private SocketExceptionUtil() {
+    }
+
+    /**
+     * Is the passed exception one that results from reading from or writing to a reset
+     * connection?
+     * <p>
+     * NOTE: This is not reliable and shouldn't be used for anything critical. We use it
+     * to make logging less noisy, false negatives are acceptable and expected. It should
+     * not produce false positives, but there's no guarantees it doesn't.
+     *
+     * @param e The exception
+     * @return true if the exception is one that signifies the connection was reset
+     */
+    public static boolean isAConnectionResetException(IOException e) {
+        String message = e.getMessage();
+        return message != null &&
+                (message.equals("Connection reset by peer")
+                        || e instanceof SocketException && message.equals("Connection reset"));
+    }
+}

--- a/src/test/java/net/openhft/chronicle/network/internal/SocketExceptionUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/network/internal/SocketExceptionUtilTest.java
@@ -1,0 +1,91 @@
+package net.openhft.chronicle.network.internal;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.network.TCPRegistry;
+import net.openhft.chronicle.network.tcp.ChronicleServerSocketChannel;
+import net.openhft.chronicle.network.tcp.ChronicleSocketChannel;
+import net.openhft.chronicle.network.tcp.ChronicleSocketChannelFactory;
+import net.openhft.chronicle.threads.Threads;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static net.openhft.chronicle.network.internal.SocketExceptionUtil.isAConnectionResetException;
+import static org.junit.Assert.*;
+
+public class SocketExceptionUtilTest {
+
+    /**
+     * Original means of detection
+     */
+    @Test
+    public void isAConnectionResetExceptionReturnsTrueWhenMessageMatches() {
+        assertTrue(isAConnectionResetException(new IOException("Connection reset by peer")));
+    }
+
+    /**
+     * Added by this change https://github.com/openjdk/jdk/commit/3a4d5db248d74020b7448b64c9f0fc072fc80470
+     * <p>
+     * Thrown in JDK 13 and above
+     */
+    @Test
+    public void isAConnectionResetExceptionReturnsTrueForSocketExceptionWithShorterMessage() {
+        assertTrue(isAConnectionResetException(new SocketException("Connection reset")));
+    }
+
+    @Test
+    public void isAConnectionResetExceptionReturnsFalseForOtherExceptions() {
+        assertFalse(isAConnectionResetException(new SocketException("Something else happened")));
+        assertFalse(isAConnectionResetException(new IOException("Something else happened")));
+    }
+
+    @Test
+    public void isAConnectionResetIsRobustAgainstNullMessages() {
+        assertFalse(isAConnectionResetException(new IOException()));
+    }
+
+    @Test
+    public void testConnectionResetDetectionForLocales() throws IOException {
+        final Locale originalDefault = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.KOREA);
+            testConnectionResetDetection();
+            Locale.setDefault(Locale.SIMPLIFIED_CHINESE);
+            testConnectionResetDetection();
+            Locale.setDefault(originalDefault);
+            testConnectionResetDetection();
+        } finally {
+            Locale.setDefault(originalDefault);
+        }
+    }
+
+    private void testConnectionResetDetection() throws IOException {
+        final ChronicleServerSocketChannel serverSocketChannel = TCPRegistry.createServerSocketChannelFor("server-address");
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(() -> {
+            // Server logic
+            try {
+                final ChronicleSocketChannel csc = serverSocketChannel.accept();
+                Jvm.pause(100); // make sure the client read has started
+                final Socket socket = csc.socketChannel().socket();
+                socket.setSoLinger(true, 0);
+                socket.close();
+            } catch (IOException e) {
+                fail(e.getMessage());
+            }
+        });
+        final ChronicleSocketChannel clientSocketChannel = ChronicleSocketChannelFactory.wrap(false, TCPRegistry.lookup("server-address"));
+        try {
+            clientSocketChannel.read(ByteBuffer.allocate(1000));
+        } catch (IOException e) {
+            assertTrue(isAConnectionResetException(e));
+        }
+        Threads.shutdown(executorService);
+    }
+}


### PR DESCRIPTION
...to prevent spurious warnings on connection reset, Fixes #172

See the issue for details.

It sucks that we have to inspect the exception this way, but given there's no ConnectionResetException I guess we have to suck it up for the time being.