### PR TITLE
https://github.com/ChronicleEnterprise/Chronicle-FIX/issues/986

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/NetworkContext.java
+++ b/src/main/java/net/openhft/chronicle/network/NetworkContext.java
@@ -120,5 +120,10 @@ public interface NetworkContext<T extends NetworkContext<T>> extends Closeable {
     default HandlerPriority periodicPriority() {
         return HandlerPriority.TIMER;
     }
+
+    /**
+     * Called when the outbound buffer becomes empty (edge-triggered)
+     */
+    default void onFlushed() {}
 }
 


### PR DESCRIPTION
Support callback to network context when outbound buffer has drained