### PR TITLE
Add OSX "Broken pipe" errors to the list of connection reset errors

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/internal/SocketExceptionUtil.java
+++ b/src/main/java/net/openhft/chronicle/network/internal/SocketExceptionUtil.java
@@ -28,7 +28,8 @@ public final class SocketExceptionUtil {
         return isALinuxJava12OrLessConnectionResetException(e)
                 || isAWindowsConnectionResetException(e)
                 || isALinuxJava13OrGreaterConnectionResetException(e)
-                || isAWindowsEstablishedConnectionAbortedException(e);
+                || isAWindowsEstablishedConnectionAbortedException(e)
+                || isAnOSXBrokenPipeException(e);
     }
 
     private static boolean isALinuxJava13OrGreaterConnectionResetException(IOException e) {
@@ -45,6 +46,10 @@ public final class SocketExceptionUtil {
 
     private static boolean isAWindowsEstablishedConnectionAbortedException(Exception e) {
         return e.getClass().equals(IOException.class) && "An established connection was aborted by the software in your host machine".equals(e.getMessage());
+    }
+
+    private static boolean isAnOSXBrokenPipeException(Exception e) {
+        return e.getClass().equals(IOException.class) && "Broken pipe".equals(e.getMessage());
     }
 
     private static final class Language {


### PR DESCRIPTION
See https://teamcity.chronicle.software/buildConfiguration/Chronicle_ChronicleFIX_SnapshotMac/685937?expandBuildProblemsSection=true&hideProblemsFromDependencies=false&expandBuildTestsSection=true&hideTestsFromDependencies=false&expandBuildChangesSection=true&showLog=685937_59645_905&logFilter=debug&logView=flowAware

This seems to be another mainfestation of "connection reset"

This list is getting pretty long. I wonder if there are any IOExceptions thrown from VanillaSocketChannelImpl.write that are worth logging.