### PR TITLE
Unignore tests

### DIFF
--- a/src/test/java/net/openhft/chronicle/network/UberHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/network/UberHandlerTest.java
@@ -261,7 +261,7 @@ class UberHandlerTest extends NetworkTestCommon {
             expectException("Rejected in onInitialize");
             REJECTING_SUB_HANDLER_SHOULD_REJECT.set(true);
             testHarness.registerSubHandler(new WritableRejectingSubHandler());
-            ignoreException("handler == null, check that the Csp/Cid has been sent");
+            expectException("handler == null, check that the Csp/Cid has been sent");
             testHarness.sendMessageToCurrentHandler();
             testHarness.callProcess();
             assertFalse(REJECTED_HANDLER_ONREAD_CALLED.get());
@@ -276,7 +276,7 @@ class UberHandlerTest extends NetworkTestCommon {
             expectException("Rejected in onRead");
             REJECTING_SUB_HANDLER_SHOULD_REJECT.set(true);
             testHarness.sendMessageToCurrentHandler();
-            ignoreException("handler == null, check that the Csp/Cid has been sent");
+            expectException("handler == null, check that the Csp/Cid has been sent");
             testHarness.sendMessageToCurrentHandler();
             testHarness.callProcess();
             assertFalse(REJECTED_HANDLER_ONWRITE_CALLED.get());
@@ -291,7 +291,7 @@ class UberHandlerTest extends NetworkTestCommon {
             expectException("Rejected in onWrite");
             REJECTING_SUB_HANDLER_SHOULD_REJECT.set(true);
             testHarness.callProcess();
-            ignoreException("handler == null, check that the Csp/Cid has been sent");
+            expectException("handler == null, check that the Csp/Cid has been sent");
             testHarness.sendMessageToCurrentHandler();
             testHarness.callProcess();
             assertFalse(REJECTED_HANDLER_ONWRITE_CALLED.get());
@@ -308,7 +308,6 @@ class UberHandlerTest extends NetworkTestCommon {
     }
 
     @Test
-    @Disabled(/* TODO FIX TEST */)
     void removeHandlerUnregistersRegisterableHandlers() {
         try (final UberHandlerTestHarness testHarness = new UberHandlerTestHarness()) {
             testHarness.registerSubHandler(new RegisterableSubHandler());
@@ -329,7 +328,6 @@ class UberHandlerTest extends NetworkTestCommon {
     }
 
     @Test
-    @Disabled(/* TODO FIX TEST */)
     void removeHandlerRemovesConnectionListenerHandlersFromNetworkContext() {
         try (final UberHandlerTestHarness testHarness = new UberHandlerTestHarness()) {
             testHarness.registerSubHandler(new ConnectionListenerSubHandler());


### PR DESCRIPTION
These just appear to work. Not sure why they were disabled/changed?

** These tests have been rock solid as far as the history seems to go and it looks like they started breaking after a flurry of Wire changes, (see [here](https://teamcity.chronicle.software/test/-7102742706145924953?currentProjectId=Chronicle_BuildAll_Checks&focusLine=0&expandTestHistoryChartSection=true)) and they seem to pass again. This test uses Wire a lot so there's every chance it was a transient situation.

The failing ones are also single threaded so unlikely it's flakiness.