### PR TITLE
Throw ClosedChannelException when FastJ8SocketChannel.read() fails due to underlying channel being closed

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/tcp/FastJ8SocketChannel.java
+++ b/src/main/java/net/openhft/chronicle/network/tcp/FastJ8SocketChannel.java
@@ -47,7 +47,7 @@ public class FastJ8SocketChannel extends VanillaSocketChannel {
         if (buf == null)
             throw new NullPointerException();
 
-        if (isBlocking() || isClosed() || !IOTools.isDirectBuffer(buf))
+        if (isBlocking() || isClosed() || !IOTools.isDirectBuffer(buf) || !super.isOpen())
             return super.read(buf);
         return read0(buf);
     }

--- a/src/test/java/net/openhft/chronicle/network/tcp/FastJ8SocketChannelTest.java
+++ b/src/test/java/net/openhft/chronicle/network/tcp/FastJ8SocketChannelTest.java
@@ -1,0 +1,41 @@
+package net.openhft.chronicle.network.tcp;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FastJ8SocketChannelTest {
+
+    @Test
+    void closedChannelExceptionIsThrownWhenAttemptIsMadeToReadFromClosedChannel() throws IOException {
+        try (final ServerSocketChannel local = ServerSocketChannel.open().bind(new InetSocketAddress("localhost", 0))) {
+            local.configureBlocking(false);
+            try (final SocketChannel remote = SocketChannel.open(local.socket().getLocalSocketAddress())) {
+                remote.configureBlocking(false);
+                final FastJ8SocketChannel fastJ8SocketChannel = new FastJ8SocketChannel(remote);
+                remote.close();
+                assertThrows(ClosedChannelException.class, () -> fastJ8SocketChannel.read(ByteBuffer.allocateDirect(100)));
+            }
+        }
+    }
+
+    @Test
+    void closedChannelExceptionIsThrownWhenAttemptIsMadeToWriteToClosedChannel() throws IOException {
+        try (final ServerSocketChannel local = ServerSocketChannel.open().bind(new InetSocketAddress("localhost", 0))) {
+            local.configureBlocking(false);
+            try (final SocketChannel remote = SocketChannel.open(local.socket().getLocalSocketAddress())) {
+                remote.configureBlocking(false);
+                final FastJ8SocketChannel fastJ8SocketChannel = new FastJ8SocketChannel(remote);
+                remote.close();
+                assertThrows(ClosedChannelException.class, () -> fastJ8SocketChannel.write(ByteBuffer.allocateDirect(100)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #214

The ClosedChannelException is handled specially in e.g. TcpEventHandler, whereas the generic IOException ends up being logged.

We could perhaps also fix this by checking before we attempt to read from the channel, but that would leave room for a race condition, and potentially re-introduce some of the slowness this class attempts to avoid.

This approach just changes the exception after the error has occurred.