### PR TITLE
Reduce log noise when we receive messages for a previously-removed handler

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/cluster/handlers/UberHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/cluster/handlers/UberHandler.java
@@ -197,7 +197,7 @@ public final class UberHandler<T extends ClusteredNetworkContext<T>> extends Csp
                     Jvm.warn().on(getClass(), "EventGroup shutdown", e);
                     removeHandler(handler);
                 } catch (RejectedHandlerException ex) {
-                    Jvm.warn().on(getClass(), "Removing rejected handler: " + handler + ", message=" + ex.getMessage(), ex);
+                    Jvm.warn().on(getClass(), "Removing rejected handler: " + handler + ", cid=" + handler.cid() + ", csp=" + handler.csp() + ", message=" + ex.getMessage(), ex);
                     removeHandler(handler);
                 }
                 return;
@@ -213,11 +213,7 @@ public final class UberHandler<T extends ClusteredNetworkContext<T>> extends Csp
                 }
             else {
                 if (handler == null) {
-                    Jvm.warn().on(getClass(), "handler == null, check that the " +
-                            "Csp/Cid has been sent, failed to " +
-                            "fully " +
-                            "process the following " +
-                            "YAML\n");
+                    Jvm.warn().on(getClass(), "Dropped message because handler == null, check that the Csp/Cid has been sent. (lastCid=" + lastCid() + ")");
                 }
             }
         } catch (ClosedIllegalStateException e) {

--- a/src/main/java/net/openhft/chronicle/network/internal/cluster/handlers/NoOpHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/internal/cluster/handlers/NoOpHandler.java
@@ -1,0 +1,98 @@
+package net.openhft.chronicle.network.internal.cluster.handlers;
+
+import net.openhft.chronicle.core.io.Closeable;
+import net.openhft.chronicle.network.NetworkContext;
+import net.openhft.chronicle.network.api.session.SubHandler;
+import net.openhft.chronicle.wire.WireIn;
+import net.openhft.chronicle.wire.WireOut;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * An immutable {@link SubHandler} that does nothing on read or write
+ *
+ * @param <T>
+ */
+public final class NoOpHandler<T extends NetworkContext<T>> implements SubHandler<T> {
+
+    private static final NoOpHandler<?> INSTANCE = new NoOpHandler<>();
+
+    private NoOpHandler() {
+        // Just to make it private, it's a singleton
+    }
+
+    public static <T extends NetworkContext<T>> SubHandler<T> instance() {
+        return (NoOpHandler<T>) INSTANCE;
+    }
+
+    @Override
+    public void cid(long cid) {
+        // Do nothing, it's stateless & shared
+    }
+
+    @Override
+    public long cid() {
+        return -1;
+    }
+
+    @Override
+    public void csp(@NotNull String cspText) {
+        // Do nothing, it's stateless & shared
+    }
+
+    @Override
+    public String csp() {
+        return "no-csp";
+    }
+
+    @Override
+    public void onRead(@NotNull WireIn inWire, @NotNull WireOut outWire) {
+        // Do nothing
+    }
+
+    @Override
+    public Closeable closable() {
+        return null;
+    }
+
+    @Override
+    public void remoteIdentifier(int remoteIdentifier) {
+        // Do nothing, it's stateless & shared
+    }
+
+    @Override
+    public void localIdentifier(int localIdentifier) {
+        // Do nothing, it's stateless & shared
+    }
+
+    @Override
+    public void onInitialize(WireOut outWire) throws RejectedExecutionException {
+        // Do nothing
+    }
+
+    @Override
+    public void closeable(Closeable closeable) {
+        // Do nothing, it's stateless & shared
+    }
+
+    @Override
+    public void close() {
+        // Do nothing
+    }
+
+    @Override
+    public boolean isClosed() {
+        return false;
+    }
+
+    @Override
+    public T nc() {
+        return null;
+    }
+
+    @Override
+    public void nc(T nc) {
+        // Do nothing, it's stateless & shared
+    }
+}

--- a/src/test/java/net/openhft/chronicle/network/UberHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/network/UberHandlerTest.java
@@ -57,7 +57,7 @@ import java.util.stream.IntStream;
 
 import static net.openhft.chronicle.network.HeaderTcpHandler.HANDLER;
 import static net.openhft.chronicle.network.cluster.handlers.UberHandler.uberHandler;
-import static net.openhft.chronicle.network.connection.CoreFields.*;
+import static net.openhft.chronicle.network.connection.CoreFields.csp;
 import static net.openhft.chronicle.network.test.TestClusterContext.forHosts;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -274,7 +274,7 @@ class UberHandlerTest extends NetworkTestCommon {
             expectException("Rejected in onInitialize");
             REJECTING_SUB_HANDLER_SHOULD_REJECT.set(true);
             testHarness.registerSubHandler(new WritableRejectingSubHandler());
-            expectException("handler == null, check that the Csp/Cid has been sent");
+            // This message will be silently dropped
             testHarness.sendMessageToCurrentHandler();
             testHarness.callProcess();
             assertFalse(REJECTED_HANDLER_ONREAD_CALLED.get());
@@ -289,7 +289,7 @@ class UberHandlerTest extends NetworkTestCommon {
             expectException("Rejected in onRead");
             REJECTING_SUB_HANDLER_SHOULD_REJECT.set(true);
             testHarness.sendMessageToCurrentHandler();
-            expectException("handler == null, check that the Csp/Cid has been sent");
+            // This message will be silently dropped
             testHarness.sendMessageToCurrentHandler();
             testHarness.callProcess();
             assertFalse(REJECTED_HANDLER_ONWRITE_CALLED.get());
@@ -304,7 +304,7 @@ class UberHandlerTest extends NetworkTestCommon {
             expectException("Rejected in onWrite");
             REJECTING_SUB_HANDLER_SHOULD_REJECT.set(true);
             testHarness.callProcess();
-            expectException("handler == null, check that the Csp/Cid has been sent");
+            // This message will be silently dropped
             testHarness.sendMessageToCurrentHandler();
             testHarness.callProcess();
             assertFalse(REJECTED_HANDLER_ONWRITE_CALLED.get());
@@ -349,6 +349,32 @@ class UberHandlerTest extends NetworkTestCommon {
             expectException("Rejected in onRead");
             testHarness.sendMessageToCurrentHandler();
             assertEquals(0, testHarness.nc().connectionListeners.size());
+        }
+    }
+
+    @Test
+    void warningIsLoggedWhenRemovedHandlersAreSwitchedTo() {
+        try (final UberHandlerTestHarness testHarness = new UberHandlerTestHarness()) {
+            final int removedHandlerCid = 1234;
+            testHarness.registerSubHandler(new RejectingSubHandler(), removedHandlerCid, "test/removed-handler");
+            REJECTING_SUB_HANDLER_SHOULD_REJECT.set(true);
+            expectException("Rejected in onRead");
+            testHarness.sendMessageToCurrentHandler();
+            expectException("Installing no-op handler to drop messages for removed handler (cid=1234, csp=test/removed-handler)");
+            testHarness.switchToSubHandler(removedHandlerCid);
+            // This should be silently ignored
+            testHarness.sendMessageToCurrentHandler();
+        }
+    }
+
+    @Test
+    void warningIsLoggedWhenNonExistentHandlerIsSwitchedToAndMessagesReceived() {
+        try (final UberHandlerTestHarness testHarness = new UberHandlerTestHarness()) {
+            testHarness.registerSubHandler(new RejectingSubHandler(), 456, "existing-handler");
+            expectException("handler not found : for CID=1234, known cids={456");
+            testHarness.switchToSubHandler(1234);
+            expectException("Dropped message because handler == null, check that the Csp/Cid has been sent. (lastCid=1234)");
+            testHarness.sendMessageToCurrentHandler();
         }
     }
 
@@ -645,11 +671,15 @@ class UberHandlerTest extends NetworkTestCommon {
         }
 
         private void registerSubHandler(WriteMarshallable subHandler) {
+            registerSubHandler(subHandler, 12345L, "12345");
+        }
+
+        private void registerSubHandler(WriteMarshallable subHandler, long cid, String csp) {
             try (final DocumentContext documentContext = inWire.writingDocument(true)) {
                 final Wire documentWire = documentContext.wire();
-                documentWire.write(csp).text("12345");
-                documentWire.write(cid).int64(12345L);
-                documentWire.write(handler).typedMarshallable(subHandler);
+                documentWire.write(CoreFields.csp).text(csp);
+                documentWire.write(CoreFields.cid).int64(cid);
+                documentWire.write(CoreFields.handler).typedMarshallable(subHandler);
             }
             uberHandler.process(inWire.bytes(), outWire.bytes(), nc);
         }
@@ -662,6 +692,14 @@ class UberHandlerTest extends NetworkTestCommon {
             try (final DocumentContext documentContext = inWire.writingDocument(false)) {
                 final Wire documentWire = documentContext.wire();
                 documentWire.write("junk").text("to trigger an onRead");
+            }
+            uberHandler.process(inWire.bytes(), outWire.bytes(), nc);
+        }
+
+        private void switchToSubHandler(long cid) {
+            try (final DocumentContext documentContext = inWire.writingDocument(true)) {
+                final Wire documentWire = documentContext.wire();
+                documentWire.write(CoreFields.cid).int64(cid);
             }
             uberHandler.process(inWire.bytes(), outWire.bytes(), nc);
         }


### PR DESCRIPTION
Fixes ChronicleEnterprise/Chronicle-Queue-Enterprise#382

Now when we receive messages for a handler we have since removed, we log that we're dropping those messages and include the CID and CSP in the log message.

When we receive messages for a CID we don't recognise, or receive messages when the handler is not set, we will still make lots of noise.