### PR TITLE
Make RemoteConnector resolve address on each connection attempt.

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/RemoteConnector.java
+++ b/src/main/java/net/openhft/chronicle/network/RemoteConnector.java
@@ -72,14 +72,11 @@ public class RemoteConnector<T extends NetworkContext<T>> extends SimpleCloseabl
         if (eventLoop instanceof ManagedCloseable)
             ((ManagedCloseable) eventLoop).throwExceptionIfClosed();
 
-        @NotNull
-        final InetSocketAddress address = TCPRegistry.lookup(remoteHostPort);
-
         @NotNull final RCEventHandler handler = new RCEventHandler(
                 remoteHostPort,
                 nc,
                 eventLoop,
-                address, retryInterval);
+                retryInterval);
 
         eventLoop.addHandler(handler);
     }
@@ -105,7 +102,6 @@ public class RemoteConnector<T extends NetworkContext<T>> extends SimpleCloseabl
 
     private final class RCEventHandler extends AbstractCloseable implements EventHandler, Closeable {
 
-        private final InetSocketAddress address;
         private final AtomicLong nextPeriod = new AtomicLong();
         private final String remoteHostPort;
         private final T nc;
@@ -115,12 +111,10 @@ public class RemoteConnector<T extends NetworkContext<T>> extends SimpleCloseabl
         RCEventHandler(final String remoteHostPort,
                        final T nc,
                        @NotNull final EventLoop eventLoop,
-                       @NotNull final InetSocketAddress address,
                        final long retryInterval) {
             this.remoteHostPort = remoteHostPort;
             this.nc = nc;
             this.eventLoop = eventLoop;
-            this.address = address;
             this.retryInterval = retryInterval;
             // add an initial delay to reduce the possibility of successful connecting to a process which is shutting down
             // this does not eliminate the issue, but is rather a tactical work around.
@@ -158,6 +152,7 @@ public class RemoteConnector<T extends NetworkContext<T>> extends SimpleCloseabl
             ChronicleSocketChannel sc = null;
             final TcpEventHandler<T> eventHandler;
 
+            final InetSocketAddress address = TCPRegistry.lookup(remoteHostPort);
             try {
                 sc = RemoteConnector.this.openSocketChannel(address);
 

--- a/src/test/java/net/openhft/chronicle/network/RemoteConnectorTest.java
+++ b/src/test/java/net/openhft/chronicle/network/RemoteConnectorTest.java
@@ -1,0 +1,78 @@
+package net.openhft.chronicle.network;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.threads.EventLoop;
+import net.openhft.chronicle.network.tcp.ChronicleServerSocketChannel;
+import net.openhft.chronicle.network.tcp.ChronicleSocketChannel;
+import net.openhft.chronicle.network.test.TestClusterContext;
+import net.openhft.chronicle.network.test.TestClusteredNetworkContext;
+import net.openhft.chronicle.testframework.Waiters;
+import net.openhft.chronicle.threads.EventGroup;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.internal.util.io.IOUtil.closeQuietly;
+
+class RemoteConnectorTest extends NetworkTestCommon {
+
+    private RemoteConnector<TestClusteredNetworkContext> remoteConnector;
+    private volatile Object connectedToSocketAddress;
+    private AtomicBoolean tcpHandlerAddedToEventLoop = new AtomicBoolean(false);
+
+    @BeforeEach
+    void setUp() {
+        remoteConnector = new RemoteConnector<>(this::createTcpEventHandler);
+    }
+
+    @Test
+    @Timeout(3)
+    void remoteConnectorLooksUpAddressOnEachIteration() throws IOException {
+        final ChronicleServerSocketChannel initialSocketChannel = TCPRegistry.createServerSocketChannelFor("test-server");
+        Jvm.startup().on(RemoteConnectorTest.class, "Initial socket address is " + initialSocketChannel.socket().getLocalSocketAddress());
+        try (final EventGroup eventGroup = EventGroup.builder().build();
+             final TestClusterContext clusterContext = new TestClusterContext();
+             final TestClusteredNetworkContext nc = new TestClusteredNetworkContext(clusterContext)) {
+            eventGroup.start();
+            closeQuietly(initialSocketChannel);
+            // Will resolve initial channel, which is closed
+            remoteConnector.connect("test-server", eventGroup, nc, 10);
+            Jvm.pause(100);
+            assertNull(connectedToSocketAddress);   // it never connected
+            // Reassign name to a fail-over channel
+            final ChronicleServerSocketChannel failOverChannel = TCPRegistry.createServerSocketChannelFor("test-server");
+            assertNotEquals(failOverChannel.socket().getLocalPort(), initialSocketChannel.socket().getLocalPort());
+            Jvm.startup().on(RemoteConnectorTest.class, "Failover socket address is " + failOverChannel.socket().getLocalSocketAddress());
+            // Accept the connection
+            try (final ChronicleSocketChannel accept = failOverChannel.accept()) {
+                // Assert we connected to the fail-over socket
+                assertNotNull(accept);
+                Waiters.waitForCondition("Client connected address not populated", () -> tcpHandlerAddedToEventLoop.get(), 3_000);
+                assertEquals(failOverChannel.socket().getLocalSocketAddress(), connectedToSocketAddress);
+            }
+        }
+    }
+
+    private TcpEventHandler<TestClusteredNetworkContext> createTcpEventHandler(TestClusteredNetworkContext nc) {
+        connectedToSocketAddress = nc.socketChannel().socket().getRemoteSocketAddress();
+        return new InstrumentedTcpHandler(nc);
+    }
+
+    private class InstrumentedTcpHandler extends TcpEventHandler<TestClusteredNetworkContext> {
+
+        public InstrumentedTcpHandler(@NotNull TestClusteredNetworkContext nc) {
+            super(nc);
+        }
+
+        @Override
+        public void eventLoop(EventLoop eventLoop) {
+            super.eventLoop(eventLoop);
+            tcpHandlerAddedToEventLoop.set(true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #232

Note that this will not produce significantly more garbage than the prior approach, as it will defer to the AddressCache, which caches addresses according to `networkaddress.cache.ttl`