### PR TITLE
Make AcceptorEventHandler#close handle the scenario where we are closing a partially initialised instance.

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/AcceptorEventHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/AcceptorEventHandler.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.channels.AsynchronousCloseException;
-import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ClosedChannelException;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -132,8 +131,10 @@ public class AcceptorEventHandler<T extends NetworkContext<T>> extends AbstractC
     }
 
     private void closeSocket() {
-        ssc.socket().close();
-        ssc.close();
+        // this can be null if we're partially initialised
+        if (ssc != null) {
+            Closeable.closeQuietly(ssc.socket(), ssc);
+        }
     }
 
     @NotNull


### PR DESCRIPTION
This is an interesting class of errors that can arise in objects that can throw in their constructors but extend AbstractCloseable. They can end up having close called on them despite never completing initialisation. It probably only occurs in test teardown, but still.

Showed up due to fix for https://github.com/OpenHFT/Chronicle-Core/issues/499