### PR TITLE
Allow socket binding for outgoing connections. Closes #236

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/AlwaysStartOnPrimaryConnectionStrategy.java
+++ b/src/main/java/net/openhft/chronicle/network/AlwaysStartOnPrimaryConnectionStrategy.java
@@ -54,6 +54,8 @@ public class AlwaysStartOnPrimaryConnectionStrategy extends AbstractMarshallable
     private ClientConnectionMonitor clientConnectionMonitor = new VanillaClientConnectionMonitor();
     private long minPauseSec = ConnectionStrategy.super.minPauseSec();
     private long maxPauseSec = ConnectionStrategy.super.maxPauseSec();
+    private String localSocketBindingHost;
+    private int localSocketBindingPort = 0;
 
     @Override
     public AlwaysStartOnPrimaryConnectionStrategy open() {
@@ -82,6 +84,9 @@ public class AlwaysStartOnPrimaryConnectionStrategy extends AbstractMarshallable
             socketAddressSupplier.resetToPrimary();
         else
             socketAddressSupplier.failoverToNextAddress();
+
+        if (fatalFailureMonitor == null)
+            fatalFailureMonitor = FatalFailureMonitor.NO_OP;
 
         for (; ; ) {
             throwExceptionIfClosed();
@@ -194,6 +199,22 @@ public class AlwaysStartOnPrimaryConnectionStrategy extends AbstractMarshallable
 
     public AlwaysStartOnPrimaryConnectionStrategy maxPauseSec(long maxPauseSec) {
         this.maxPauseSec = maxPauseSec;
+        return this;
+    }
+
+    @Override
+    public @Nullable InetSocketAddress localSocketBinding() {
+        // Create a new InetSocketAddress each time to allow host to be re-resolved
+        return localSocketBindingHost != null ? new InetSocketAddress(localSocketBindingHost, localSocketBindingPort) : null;
+    }
+
+    public AlwaysStartOnPrimaryConnectionStrategy localSocketBindingHost(String localSocketBindingHost) {
+        this.localSocketBindingHost = localSocketBindingHost;
+        return this;
+    }
+
+    public AlwaysStartOnPrimaryConnectionStrategy localSocketBindingPort(int localSocketBindingPort) {
+        this.localSocketBindingPort = localSocketBindingPort;
         return this;
     }
 }

--- a/src/main/java/net/openhft/chronicle/network/ChronicleSocketChannelBuilder.java
+++ b/src/main/java/net/openhft/chronicle/network/ChronicleSocketChannelBuilder.java
@@ -1,0 +1,131 @@
+package net.openhft.chronicle.network;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.network.tcp.ChronicleSocket;
+import net.openhft.chronicle.network.tcp.ChronicleSocketChannel;
+import net.openhft.chronicle.network.tcp.ChronicleSocketChannelFactory;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+
+import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
+import static net.openhft.chronicle.network.connection.TcpChannelHub.TCP_BUFFER;
+
+public class ChronicleSocketChannelBuilder {
+
+    @NotNull
+    private final InetSocketAddress socketAddress;
+    private int tcpBufferSize = Jvm.getInteger("tcp.client.buffer.size", TCP_BUFFER);
+    private int socketConnectionTimeoutMs = Jvm.getInteger("client.timeout", 500);
+    @Nullable
+    private InetSocketAddress localBinding;
+    private boolean tcpNoDelay = !TcpEventHandler.DISABLE_TCP_NODELAY;
+
+    public ChronicleSocketChannelBuilder(@NotNull InetSocketAddress socketAddress) {
+        this.socketAddress = socketAddress;
+    }
+
+    /**
+     * Set the TCP buffer size
+     *
+     * @param tcpBufferSize The TCP buffer size in bytes
+     * @return this
+     */
+    public ChronicleSocketChannelBuilder tcpBufferSize(int tcpBufferSize) {
+        this.tcpBufferSize = tcpBufferSize;
+        return this;
+    }
+
+    /**
+     * Set the socket connection timeout
+     *
+     * @param socketConnectionTimeoutMs the socket connection timeout in milliseconds
+     * @return this
+     */
+    public ChronicleSocketChannelBuilder socketConnectionTimeoutMs(int socketConnectionTimeoutMs) {
+        this.socketConnectionTimeoutMs = socketConnectionTimeoutMs;
+        return this;
+    }
+
+    /**
+     * Set whether to enable/disable <a href="https://en.wikipedia.org/wiki/Nagle%27s_algorithm">Nagle's algorithm</a> for this socket
+     *
+     * @param tcpNoDelay
+     * @return
+     */
+    public ChronicleSocketChannelBuilder tcpNoDelay(boolean tcpNoDelay) {
+        this.tcpNoDelay = tcpNoDelay;
+        return this;
+    }
+
+    /**
+     * Set the local socket to bind to
+     *
+     * @param localBinding The local socket to bind to, or null to not bind to any local socket
+     * @return this
+     */
+    public ChronicleSocketChannelBuilder localBinding(InetSocketAddress localBinding) {
+        this.localBinding = localBinding;
+        return this;
+    }
+
+    /**
+     * Open a socket channel with the builder's current settings
+     *
+     * @return The opened channel, or null if no channel could be opened
+     * @throws IOException if something goes wrong opening the channel
+     */
+    @Nullable
+    public ChronicleSocketChannel open() throws IOException {
+        final ChronicleSocketChannel result = ChronicleSocketChannelFactory.wrap();
+        @Nullable Selector selector = null;
+        boolean failed = true;
+        try {
+            if (localBinding != null) {
+                result.bind(localBinding);
+            }
+            result.configureBlocking(false);
+            ChronicleSocket socket = result.socket();
+            socket.setTcpNoDelay(tcpNoDelay);
+            socket.setReceiveBufferSize(tcpBufferSize);
+            socket.setSendBufferSize(tcpBufferSize);
+            socket.setSoTimeout(0);
+            socket.setSoLinger(false, 0);
+            result.connect(socketAddress);
+
+            selector = Selector.open();
+            result.register(selector, SelectionKey.OP_CONNECT);
+
+            int select = selector.select(socketConnectionTimeoutMs);
+            if (select == 0) {
+                if (Jvm.isDebugEnabled(ConnectionStrategy.class))
+                    Jvm.debug().on(ConnectionStrategy.class, "Timed out attempting to connect to " + socketAddress);
+                return null;
+            } else {
+                try {
+                    if (!result.finishConnect())
+                        return null;
+
+                } catch (IOException e) {
+                    if (Jvm.isDebugEnabled(ConnectionStrategy.class))
+                        Jvm.debug().on(ConnectionStrategy.class, "Failed to connect to " + socketAddress + " " + e);
+                    return null;
+                }
+            }
+
+            failed = false;
+            return result;
+
+        } catch (Exception e) {
+            return null;
+        } finally {
+            closeQuietly(selector);
+            if (failed)
+                closeQuietly(result);
+        }
+    }
+}

--- a/src/main/java/net/openhft/chronicle/network/connection/FatalFailureConnectionStrategy.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/FatalFailureConnectionStrategy.java
@@ -66,6 +66,8 @@ public class FatalFailureConnectionStrategy extends AbstractMarshallableCfg impl
     private final boolean blocking;
     private int tcpBufferSize;
     private ClientConnectionMonitor clientConnectionMonitor = new VanillaClientConnectionMonitor();
+    private String localSocketBindingHost;
+    private int localSocketBindingPort = 0;
     private transient AtomicBoolean isClosed;
     private transient boolean hasSentFatalFailure;
 
@@ -201,5 +203,20 @@ public class FatalFailureConnectionStrategy extends AbstractMarshallableCfg impl
     public void readMarshallable(@NotNull WireIn wire) throws IORuntimeException {
         super.readMarshallable(wire);
         init();
+    }
+
+    @Override
+    public @Nullable InetSocketAddress localSocketBinding() {
+        return localSocketBindingHost != null ? new InetSocketAddress(localSocketBindingHost, localSocketBindingPort) : null;
+    }
+
+    public FatalFailureConnectionStrategy localSocketBindingHost(String localSocketBindingHost) {
+        this.localSocketBindingHost = localSocketBindingHost;
+        return this;
+    }
+
+    public FatalFailureConnectionStrategy localSocketBindingPort(int localSocketBindingPort) {
+        this.localSocketBindingPort = localSocketBindingPort;
+        return this;
     }
 }

--- a/src/main/java/net/openhft/chronicle/network/connection/FatalFailureMonitor.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/FatalFailureMonitor.java
@@ -25,6 +25,15 @@ public interface FatalFailureMonitor {
     Logger LOG = LoggerFactory.getLogger(FatalFailureMonitor.class);
 
     /**
+     * A no-op implementation
+     */
+    FatalFailureMonitor NO_OP = new FatalFailureMonitor() {
+        @Override
+        public void onFatalFailure(@Nullable String name, String message) {
+        }
+    };
+
+    /**
      * called if all the connection attempts/(and/or timeouts) determined by the connection strategy has been exhausted
      *
      * @param name    the name of the connection

--- a/src/main/java/net/openhft/chronicle/network/tcp/ChronicleSocket.java
+++ b/src/main/java/net/openhft/chronicle/network/tcp/ChronicleSocket.java
@@ -56,6 +56,8 @@ public interface ChronicleSocket {
 
     Object getRemoteSocketAddress();
 
+    Object getLocalSocketAddress();
+
     int getLocalPort();
 
 }

--- a/src/main/java/net/openhft/chronicle/network/tcp/ChronicleSocketChannel.java
+++ b/src/main/java/net/openhft/chronicle/network/tcp/ChronicleSocketChannel.java
@@ -19,6 +19,7 @@
 package net.openhft.chronicle.network.tcp;
 
 import net.openhft.chronicle.core.io.Closeable;
+import net.openhft.chronicle.network.ChronicleSocketChannelBuilder;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -30,6 +31,10 @@ import java.nio.channels.SocketChannel;
 
 public interface ChronicleSocketChannel extends Closeable {
 
+    static ChronicleSocketChannelBuilder builder(InetSocketAddress socketAddress) {
+        return new ChronicleSocketChannelBuilder(socketAddress);
+    }
+
     int read(ByteBuffer byteBuffer) throws IOException;
 
     int write(ByteBuffer byteBuffer) throws IOException;
@@ -39,6 +44,8 @@ public interface ChronicleSocketChannel extends Closeable {
     void configureBlocking(boolean blocking) throws IOException;
 
     InetSocketAddress getLocalAddress() throws IOException;
+
+    void bind(InetSocketAddress localAddress) throws IOException;
 
     InetSocketAddress getRemoteAddress() throws IOException;
 

--- a/src/main/java/net/openhft/chronicle/network/tcp/ChronicleSocketFactory.java
+++ b/src/main/java/net/openhft/chronicle/network/tcp/ChronicleSocketFactory.java
@@ -81,12 +81,14 @@ public enum ChronicleSocketFactory {
             }
 
             @Override
+            public Object getLocalSocketAddress() {
+                return socket.getLocalSocketAddress();
+            }
+
+            @Override
             public int getLocalPort() {
                 return socket.getLocalPort();
             }
-
-        }
-
-                ;
+        };
     }
 }

--- a/src/main/java/net/openhft/chronicle/network/tcp/VanillaSocketChannel.java
+++ b/src/main/java/net/openhft/chronicle/network/tcp/VanillaSocketChannel.java
@@ -88,6 +88,11 @@ public class VanillaSocketChannel extends AbstractCloseable implements Chronicle
     }
 
     @Override
+    public void bind(final InetSocketAddress localAddress) throws IOException {
+        socketChannel.bind(localAddress);
+    }
+
+    @Override
     public InetSocketAddress getRemoteAddress() throws IORuntimeException {
         try {
             return (InetSocketAddress) socketChannel.getRemoteAddress();

--- a/src/test/java/net/openhft/chronicle/network/AlwaysStartOnPrimaryConnectionStrategyTest.java
+++ b/src/test/java/net/openhft/chronicle/network/AlwaysStartOnPrimaryConnectionStrategyTest.java
@@ -18,17 +18,23 @@
 
 package net.openhft.chronicle.network;
 
+import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.network.connection.FatalFailureMonitor;
 import net.openhft.chronicle.network.connection.SocketAddressSupplier;
+import net.openhft.chronicle.network.tcp.ChronicleServerSocketChannel;
+import net.openhft.chronicle.network.tcp.ChronicleSocketChannel;
+import net.openhft.chronicle.network.util.TestServer;
 import net.openhft.chronicle.wire.JSONWire;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.CountDownLatch;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static net.openhft.chronicle.network.util.TestUtil.getAvailablePortNumber;
+import static org.junit.jupiter.api.Assertions.*;
 
 class AlwaysStartOnPrimaryConnectionStrategyTest extends NetworkTestCommon {
     private static String uri;
@@ -42,12 +48,11 @@ class AlwaysStartOnPrimaryConnectionStrategyTest extends NetworkTestCommon {
 
     @Test
     @Timeout(1)
-    void connect_attempts_should_stop_when_thread_is_interrupted() throws InterruptedException {
+    void connectAttemptsShouldStopWhenThreadIsInterrupted() throws InterruptedException {
         Thread thread = new Thread(() -> {
             ConnectionStrategy strategy = new AlwaysStartOnPrimaryConnectionStrategy();
             try {
-                strategy.connect("unavailable_uri", SocketAddressSupplier.uri(uri), false, new FatalFailureMonitor() {
-                });
+                strategy.connect("unavailable_uri", SocketAddressSupplier.uri(uri), false, FatalFailureMonitor.NO_OP);
             } catch (InterruptedException e) {
                 fail("AlwaysStartOnPrimaryConnectionStrategy#connect should not have propagated the " + e.getClass());
             }
@@ -58,13 +63,31 @@ class AlwaysStartOnPrimaryConnectionStrategyTest extends NetworkTestCommon {
     }
 
     @Test
-    void test() {
+    void testIsSerializable() {
         TCPRegistry.reset();
         final AlwaysStartOnPrimaryConnectionStrategy alwaysStartOnPrimaryConnectionStrategy = new AlwaysStartOnPrimaryConnectionStrategy();
         JSONWire jsonWire = new JSONWire().useTypes(true);
         jsonWire.getValueOut().object(alwaysStartOnPrimaryConnectionStrategy);
         assertEquals("{\"@AlwaysStartOnPrimaryConnectionStrategy\":{}}", jsonWire.bytes().toString());
+    }
 
+    @Test
+    void testLocalBinding() throws InterruptedException, IOException {
+        final AlwaysStartOnPrimaryConnectionStrategy strategy = new AlwaysStartOnPrimaryConnectionStrategy();
+        final String localSocketBindingHost = "127.0.0.75";
+        int localPort = getAvailablePortNumber();
+        strategy.localSocketBindingHost(localSocketBindingHost)
+                .localSocketBindingPort(localPort);
+        try (TestServer testServer = new TestServer("localBindingTestServer")) {
+            testServer.prepareToAcceptAConnection();
+            Jvm.pause(100);
+            try (final ChronicleSocketChannel channel = strategy.connect("local_server", SocketAddressSupplier.uri(testServer.uri()), false, null)) {
+                assertNotNull(channel);
+                final InetSocketAddress localSocketAddress = (InetSocketAddress) channel.socket().getLocalSocketAddress();
+                assertEquals(localPort, localSocketAddress.getPort());
+                assertEquals(localSocketBindingHost, localSocketAddress.getHostName());
+            }
+        }
     }
 
 }

--- a/src/test/java/net/openhft/chronicle/network/NetworkTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/network/NetworkTestCommon.java
@@ -56,7 +56,7 @@ public class NetworkTestCommon {
 
     @BeforeEach
     void recordExceptions() {
-        exceptionTracker = JvmExceptionTracker.create();
+        exceptionTracker = JvmExceptionTracker.create(false);
         exceptionTracker.ignoreException("unable to connect to any of the hosts");
     }
 

--- a/src/test/java/net/openhft/chronicle/network/util/TestServer.java
+++ b/src/test/java/net/openhft/chronicle/network/util/TestServer.java
@@ -1,0 +1,66 @@
+package net.openhft.chronicle.network.util;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.AbstractCloseable;
+import net.openhft.chronicle.core.io.Closeable;
+import net.openhft.chronicle.network.TCPRegistry;
+import net.openhft.chronicle.network.tcp.ChronicleServerSocketChannel;
+import net.openhft.chronicle.network.tcp.ChronicleSocketChannel;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.CountDownLatch;
+
+public class TestServer extends AbstractCloseable {
+
+    private final ChronicleServerSocketChannel serverSocketChannel;
+    private final String uri;
+    private Thread serverThread;
+
+    public TestServer(String registryHostName) throws IOException {
+        serverSocketChannel = TCPRegistry.createServerSocketChannelFor(registryHostName);
+        final InetSocketAddress localSocketAddress = (InetSocketAddress) serverSocketChannel.socket().getLocalSocketAddress();
+        uri = localSocketAddress.getHostName() + ":" + localSocketAddress.getPort();
+        Jvm.startup().on(TestServer.class, "Test server URI is " + uri);
+    }
+
+    public void prepareToAcceptAConnection() {
+        CountDownLatch latch = new CountDownLatch(2);
+        serverThread = new Thread(() -> {
+            waitAtLatch(latch);
+            try (final ChronicleSocketChannel accept = serverSocketChannel.accept()) {
+                Jvm.startup().on(TestServer.class, "Connected to " + accept.getRemoteAddress());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        serverThread.start();
+        waitAtLatch(latch);
+    }
+
+    private void waitAtLatch(CountDownLatch latch) {
+        try {
+            latch.countDown();
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected void performClose() {
+        Closeable.closeQuietly(serverSocketChannel);
+        try {
+            if (serverThread != null)
+                serverThread.join();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String uri() {
+        return uri;
+    }
+}

--- a/src/test/java/net/openhft/chronicle/network/util/TestUtil.java
+++ b/src/test/java/net/openhft/chronicle/network/util/TestUtil.java
@@ -1,0 +1,21 @@
+package net.openhft.chronicle.network.util;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public enum TestUtil {
+    ;
+
+    /**
+     * Get a port number that's most likely available
+     *
+     * @return a port number that's available
+     */
+    public static int getAvailablePortNumber() {
+        try (final ServerSocket serverSocket = new ServerSocket(0)) {
+            return serverSocket.getLocalPort();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
It turns out this does work on Linux. At least on the two that I tested it on.

This allows users to specify an IP address to bind outgoing connections to in the two ConnectionStrategies we have. E.g.

```yaml
!FatalFailureConnectionStrategy {
   attempts: 3,
   blocking: false,
   localSocketBindingHost: 192.168.50.1,
   localSocketBindingPort: 123,   # not recommended to bind
   ....
}
```
Although binding the local port is not recommended as it may mean only a single outbound connection can be established (default is to bind it to 0 or any free port)
