### PR TITLE
Properly handle throw of InvalidEventHandlerException from TcpEventHandler.action0

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/TcpEventHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/TcpEventHandler.java
@@ -199,9 +199,11 @@ public class TcpEventHandler<T extends NetworkContext<T>>
 
         try {
             return action0();
+        } catch (InvalidEventHandlerException t) {
+            throw t;
         } catch (Throwable t) {
             if (this.isClosed())
-                throw new InvalidEventHandlerException();
+                throw new InvalidEventHandlerException(t);
             throw Jvm.rethrow(t);
         }
     }


### PR DESCRIPTION
Previously InvalidEventHandlerException thrown from TcpEventHandler.action0 was not being propogated

Build all: https://teamcity.chronicle.software/project/Chronicle_BuildAll?branch=feature%2Fhandle-invalid-event-handler-exception&buildTypeTab=overview&mode=builds