### PR TITLE
Stop using deprecated BlockingEventLoop constructor

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/cluster/ClusterContext.java
+++ b/src/main/java/net/openhft/chronicle/network/cluster/ClusterContext.java
@@ -135,7 +135,7 @@ public abstract class ClusterContext<C extends ClusterContext<C, T>, T extends C
 
         if (hd.connectUri() == null)
             return;
-        acceptorLoop = new BlockingEventLoop(eventLoop(), clusterNamePrefix() + "acceptor-" + localIdentifier, Pauser.balanced());
+        acceptorLoop = new BlockingEventLoop(eventLoop(), clusterNamePrefix() + "acceptor-" + localIdentifier, Pauser::balanced);
         try {
             acceptorEventHandler = new ClusterAcceptorEventHandler<>(hd.connectUri(), castThis());
 


### PR DESCRIPTION
This one wasn't thread-safe