### PR TITLE
Deprecate TcpChannelHub to be moved into DataGrid (its only remaining use)

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/ChronicleSocketChannelBuilder.java
+++ b/src/main/java/net/openhft/chronicle/network/ChronicleSocketChannelBuilder.java
@@ -13,13 +13,13 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
-import static net.openhft.chronicle.network.connection.TcpChannelHub.TCP_BUFFER;
+import static net.openhft.chronicle.network.NetworkUtil.TCP_BUFFER_SIZE;
 
 public class ChronicleSocketChannelBuilder {
 
     @NotNull
     private final InetSocketAddress socketAddress;
-    private int tcpBufferSize = Jvm.getInteger("tcp.client.buffer.size", TCP_BUFFER);
+    private int tcpBufferSize = Jvm.getInteger("tcp.client.buffer.size", TCP_BUFFER_SIZE);
     private int socketConnectionTimeoutMs = Jvm.getInteger("client.timeout", 500);
     @Nullable
     private InetSocketAddress localBinding;

--- a/src/main/java/net/openhft/chronicle/network/HeaderTcpHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/HeaderTcpHandler.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Function;
 
-import static net.openhft.chronicle.network.connection.TcpChannelHub.TCP_USE_PADDING;
+import static net.openhft.chronicle.network.NetworkUtil.TCP_USE_PADDING;
 
 public class HeaderTcpHandler<T extends NetworkContext<T>> extends SimpleCloseable implements TcpHandler<T> {
 

--- a/src/main/java/net/openhft/chronicle/network/NetworkUtil.java
+++ b/src/main/java/net/openhft/chronicle/network/NetworkUtil.java
@@ -1,0 +1,56 @@
+package net.openhft.chronicle.network;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.IORuntimeException;
+
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+
+import static net.openhft.chronicle.core.Jvm.getInteger;
+
+public enum NetworkUtil {
+    ;
+    public static final int TCP_BUFFER_SIZE = getTcpBufferSize();
+    public static final int TCP_SAFE_SIZE = getInteger("tcp.safe.size", 128 << 10);
+    public static final boolean TCP_USE_PADDING = Jvm.getBoolean("tcp.use.padding", false);
+
+    private static int getTcpBufferSize() {
+        final String sizeStr = Jvm.getProperty("TcpEventHandler.tcpBufferSize");
+        if (sizeStr != null && !sizeStr.isEmpty())
+            try {
+                final int size = Integer.parseInt(sizeStr);
+                if (size >= 64 << 10)
+                    return size;
+            } catch (Exception e) {
+                Jvm.warn().on(NetworkUtil.class, "Unable to parse tcpBufferSize=" + sizeStr, e);
+            }
+        try {
+            try (ServerSocket ss = new ServerSocket(0)) {
+                try (Socket s = new Socket("localhost", ss.getLocalPort())) {
+                    s.setReceiveBufferSize(4 << 20);
+                    s.setSendBufferSize(4 << 20);
+                    final int size = Math.min(s.getReceiveBufferSize(), s.getSendBufferSize());
+                    (size >= 128 << 10 ? Jvm.debug() : Jvm.warn())
+                            .on(NetworkUtil.class, "tcpBufferSize = " + size / 1024.0 + " KiB");
+                    return size;
+                }
+            }
+        } catch (Exception e) {
+            throw new IORuntimeException(e); // problem with networking subsystem.
+        }
+    }
+
+    public static void setTcpNoDelay(Socket socket, boolean tcpNoDelay) throws SocketException {
+        for (int i = 10; i >= 0; i--) {
+            try {
+
+                socket.setTcpNoDelay(tcpNoDelay);
+            } catch (SocketException se) {
+                if (i == 0)
+                    throw se;
+                Jvm.pause(1);
+            }
+        }
+    }
+}

--- a/src/main/java/net/openhft/chronicle/network/RemoteConnector.java
+++ b/src/main/java/net/openhft/chronicle/network/RemoteConnector.java
@@ -25,7 +25,6 @@ import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.core.threads.HandlerPriority;
 import net.openhft.chronicle.core.threads.InvalidEventHandlerException;
 import net.openhft.chronicle.core.util.ThrowingFunction;
-import net.openhft.chronicle.network.connection.TcpChannelHub;
 import net.openhft.chronicle.network.tcp.ChronicleSocket;
 import net.openhft.chronicle.network.tcp.ChronicleSocketChannel;
 import net.openhft.chronicle.network.tcp.ChronicleSocketChannelFactory;
@@ -45,6 +44,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
 
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
+import static net.openhft.chronicle.network.NetworkUtil.TCP_BUFFER_SIZE;
 import static net.openhft.chronicle.network.NetworkStatsListener.notifyHostPort;
 
 public class RemoteConnector<T extends NetworkContext<T>> extends SimpleCloseable {
@@ -56,7 +56,7 @@ public class RemoteConnector<T extends NetworkContext<T>> extends SimpleCloseabl
     private final List<java.io.Closeable> closeables = Collections.synchronizedList(new ArrayList<>());
 
     public RemoteConnector(@NotNull final ThrowingFunction<T, TcpEventHandler<T>, IOException> tcpEventHandlerFactory) {
-        this.tcpBufferSize = Jvm.getInteger("tcp.client.buffer.size", TcpChannelHub.TCP_BUFFER);
+        this.tcpBufferSize = Jvm.getInteger("tcp.client.buffer.size", TCP_BUFFER_SIZE);
         this.tcpHandlerSupplier = tcpEventHandlerFactory;
     }
 

--- a/src/main/java/net/openhft/chronicle/network/WireTcpHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/WireTcpHandler.java
@@ -26,8 +26,8 @@ import net.openhft.chronicle.wire.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static net.openhft.chronicle.network.NetworkUtil.TCP_USE_PADDING;
 import static net.openhft.chronicle.network.connection.CoreFields.reply;
-import static net.openhft.chronicle.network.connection.TcpChannelHub.TCP_USE_PADDING;
 import static net.openhft.chronicle.wire.WireType.BINARY;
 import static net.openhft.chronicle.wire.WireType.DELTA_BINARY;
 import static net.openhft.chronicle.wire.WriteMarshallable.EMPTY;

--- a/src/main/java/net/openhft/chronicle/network/connection/AbstractAsyncSubscription.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/AbstractAsyncSubscription.java
@@ -19,6 +19,11 @@ package net.openhft.chronicle.network.connection;
 
 import net.openhft.chronicle.wire.WireOut;
 import org.jetbrains.annotations.NotNull;
+
+/**
+ * @deprecated This has been moved to DataGrid without a replacement
+ */
+@Deprecated(/* For removal in x.25 */)
 public abstract class AbstractAsyncSubscription implements AsyncSubscription {
 
     private final long tid;

--- a/src/main/java/net/openhft/chronicle/network/connection/AbstractAsyncTemporarySubscription.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/AbstractAsyncTemporarySubscription.java
@@ -20,6 +20,10 @@ package net.openhft.chronicle.network.connection;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * @deprecated This has been moved to DataGrid without a replacement
+ */
+@Deprecated(/* For removal in x.25 */)
 public abstract class AbstractAsyncTemporarySubscription extends AbstractAsyncSubscription
         implements AsyncTemporarySubscription {
 

--- a/src/main/java/net/openhft/chronicle/network/connection/AbstractConnectionStrategy.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/AbstractConnectionStrategy.java
@@ -15,10 +15,10 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import static net.openhft.chronicle.network.connection.TcpChannelHub.TCP_BUFFER;
+import static net.openhft.chronicle.network.NetworkUtil.TCP_BUFFER_SIZE;
 
 public abstract class AbstractConnectionStrategy extends AbstractMarshallableCfg implements ConnectionStrategy {
-    protected int tcpBufferSize = Jvm.getInteger("tcp.client.buffer.size", TCP_BUFFER);
+    protected int tcpBufferSize = Jvm.getInteger("tcp.client.buffer.size", TCP_BUFFER_SIZE);
     private final transient AtomicBoolean isClosed = new AtomicBoolean(false);
     protected ClientConnectionMonitor clientConnectionMonitor = new VanillaClientConnectionMonitor();
     protected String localSocketBindingHost;

--- a/src/main/java/net/openhft/chronicle/network/connection/AbstractStatelessClient.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/AbstractStatelessClient.java
@@ -40,6 +40,10 @@ import java.util.function.Function;
 import static java.lang.ThreadLocal.withInitial;
 import static net.openhft.chronicle.network.connection.CoreFields.reply;
 
+/**
+ * @deprecated This has been moved to DataGrid without a replacement
+ */
+@Deprecated(/* For removal in x.25 */)
 public abstract class AbstractStatelessClient<E extends ParameterizeWireKey>
         extends SimpleCloseable
         implements Closeable {

--- a/src/main/java/net/openhft/chronicle/network/connection/VanillaWireOutPublisher.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/VanillaWireOutPublisher.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 
-import static net.openhft.chronicle.network.connection.TcpChannelHub.TCP_USE_PADDING;
+import static net.openhft.chronicle.network.NetworkUtil.*;
 
 public class VanillaWireOutPublisher extends AbstractCloseable implements WireOutPublisher {
 
@@ -39,7 +39,7 @@ public class VanillaWireOutPublisher extends AbstractCloseable implements WireOu
     private String connectionDescription = "?";
 
     public VanillaWireOutPublisher(@NotNull WireType wireType) {
-        bytes = Bytes.elasticByteBuffer(TcpChannelHub.TCP_BUFFER);
+        bytes = Bytes.elasticByteBuffer(TCP_BUFFER_SIZE);
         final WireType wireType0 = wireType == WireType.DELTA_BINARY ? WireType.BINARY : wireType;
         wire = wireType0.apply(bytes);
         wire.usePadding(TCP_USE_PADDING);
@@ -67,7 +67,7 @@ public class VanillaWireOutPublisher extends AbstractCloseable implements WireOu
                 if (YamlLogging.showServerWrites())
                     logBuffer();
 
-                if (bytes.writePosition() > TcpChannelHub.TCP_BUFFER)
+                if (bytes.writePosition() > TCP_BUFFER_SIZE)
                     return; // Write next time to prevent TCP buffer overflow.
 
                 bytes.write(this.bytes);
@@ -110,7 +110,7 @@ public class VanillaWireOutPublisher extends AbstractCloseable implements WireOu
         throwExceptionIfClosed();
 
         synchronized (lock()) {
-            return wire.bytes().writePosition() < TcpChannelHub.TCP_SAFE_SIZE; // don't attempt
+            return wire.bytes().writePosition() < TCP_SAFE_SIZE; // don't attempt
             // to fill the buffer completely.
         }
     }

--- a/src/main/java/net/openhft/chronicle/network/tcp/ChronicleSocketFactory.java
+++ b/src/main/java/net/openhft/chronicle/network/tcp/ChronicleSocketFactory.java
@@ -18,7 +18,7 @@
 
 package net.openhft.chronicle.network.tcp;
 
-import net.openhft.chronicle.network.connection.TcpChannelHub;
+import net.openhft.chronicle.network.NetworkUtil;
 
 import java.io.IOException;
 import java.net.Socket;
@@ -32,7 +32,7 @@ public enum ChronicleSocketFactory {
 
             @Override
             public void setTcpNoDelay(final boolean tcpNoDelay) throws SocketException {
-                TcpChannelHub.setTcpNoDelay(socket, tcpNoDelay);
+                NetworkUtil.setTcpNoDelay(socket, tcpNoDelay);
             }
 
             @Override

--- a/src/test/java/net/openhft/chronicle/network/connection/FatalFailureConnectionStrategyTest.java
+++ b/src/test/java/net/openhft/chronicle/network/connection/FatalFailureConnectionStrategyTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Timeout;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
+import static net.openhft.chronicle.network.NetworkUtil.TCP_BUFFER_SIZE;
 import static net.openhft.chronicle.network.util.TestUtil.getAvailablePortNumber;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -58,8 +59,8 @@ class FatalFailureConnectionStrategyTest {
         assertEquals(expectedToString, strategy.toString());
         assertEquals(strategy.toString(), strategyFromYaml.toString());
 
-        assertEquals(TcpChannelHub.TCP_BUFFER, strategy.tcpBufferSize);
-        assertEquals(TcpChannelHub.TCP_BUFFER, strategyFromYaml.tcpBufferSize);
+        assertEquals(TCP_BUFFER_SIZE, strategy.tcpBufferSize);
+        assertEquals(TCP_BUFFER_SIZE, strategyFromYaml.tcpBufferSize);
         assertNotNull(strategy.clientConnectionMonitor);
         assertNotNull(strategyFromYaml.clientConnectionMonitor);
 

--- a/src/test/java/net/openhft/performance/tests/network/PingPongWithMains.java
+++ b/src/test/java/net/openhft/performance/tests/network/PingPongWithMains.java
@@ -20,7 +20,6 @@ package net.openhft.performance.tests.network;
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.network.*;
-import net.openhft.chronicle.network.connection.TcpChannelHub;
 import net.openhft.chronicle.network.tcp.ChronicleSocketChannel;
 import net.openhft.chronicle.threads.EventGroup;
 import net.openhft.chronicle.threads.Pauser;
@@ -126,7 +125,6 @@ public class PingPongWithMains {
         //       testThroughput(sc);
         testLatency(serverHostPort, WireType.BINARY, sc);
 
-        TcpChannelHub.closeAllHubs();
         TCPRegistry.reset();
     }
 

--- a/src/test/java/net/openhft/performance/tests/network/SimpleServerAndClientTest.java
+++ b/src/test/java/net/openhft/performance/tests/network/SimpleServerAndClientTest.java
@@ -42,8 +42,8 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeoutException;
 
+import static net.openhft.chronicle.network.NetworkUtil.TCP_USE_PADDING;
 import static net.openhft.chronicle.network.connection.SocketAddressSupplier.uri;
-import static net.openhft.chronicle.network.connection.TcpChannelHub.TCP_USE_PADDING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SimpleServerAndClientTest extends NetworkTestCommon {

--- a/src/test/java/net/openhft/performance/tests/network/VerySimpleClientTest.java
+++ b/src/test/java/net/openhft/performance/tests/network/VerySimpleClientTest.java
@@ -32,14 +32,12 @@
 package net.openhft.performance.tests.network;
 
 import net.openhft.chronicle.bytes.Bytes;
-import net.openhft.chronicle.core.io.AbstractReferenceCounted;
 import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.network.AcceptorEventHandler;
 import net.openhft.chronicle.network.NetworkTestCommon;
 import net.openhft.chronicle.network.TCPRegistry;
 import net.openhft.chronicle.network.VanillaNetworkContext;
-import net.openhft.chronicle.network.connection.TcpChannelHub;
 import net.openhft.chronicle.network.tcp.ChronicleSocket;
 import net.openhft.chronicle.network.tcp.ChronicleSocketChannel;
 import net.openhft.chronicle.threads.EventGroup;
@@ -55,7 +53,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static net.openhft.chronicle.network.connection.TcpChannelHub.TCP_USE_PADDING;
+import static net.openhft.chronicle.network.NetworkUtil.TCP_USE_PADDING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class VerySimpleClientTest extends NetworkTestCommon {
@@ -89,7 +87,6 @@ class VerySimpleClientTest extends NetworkTestCommon {
     @AfterEach
     void tearDown() {
         Closeable.closeQuietly(sc, eg, client);
-        TcpChannelHub.closeAllHubs();
         inWire.bytes().releaseLast();
         outWire.bytes().releaseLast();
     }

--- a/src/test/java/net/openhft/performance/tests/network/WireTcpHandlerTest.java
+++ b/src/test/java/net/openhft/performance/tests/network/WireTcpHandlerTest.java
@@ -20,7 +20,6 @@ package net.openhft.performance.tests.network;
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.core.threads.EventLoop;
 import net.openhft.chronicle.network.*;
-import net.openhft.chronicle.network.connection.TcpChannelHub;
 import net.openhft.chronicle.network.tcp.ChronicleSocketChannel;
 import net.openhft.chronicle.threads.EventGroup;
 import net.openhft.chronicle.wire.*;
@@ -34,7 +33,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Function;
 
-import static net.openhft.chronicle.network.connection.TcpChannelHub.TCP_USE_PADDING;
+import static net.openhft.chronicle.network.NetworkUtil.TCP_USE_PADDING;
 import static net.openhft.performance.tests.network.LegacyHanderFactory.simpleTcpEventHandlerFactory;
 
 /*
@@ -144,7 +143,6 @@ class WireTcpHandlerTest extends NetworkTestCommon {
                 testLatency(desc, wireType, sc);
 
                 eg.stop();
-                TcpChannelHub.closeAllHubs();
             }
         }
         YamlLogging.setAll(logging);


### PR DESCRIPTION
There are some constants and a static utility method that seem to be used in other places, but I've moved them to `NetworkUtil` (happy to bikeshed that name/decision)