### PR TITLE
Deprecate more TcpChannelHub related stuff

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/connection/AsyncSubscription.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/AsyncSubscription.java
@@ -20,6 +20,10 @@ package net.openhft.chronicle.network.connection;
 import net.openhft.chronicle.wire.WireIn;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * @deprecated This has been moved to DataGrid without a replacement
+ */
+@Deprecated(/* For removal in x.25 */)
 interface AsyncSubscription {
 
     /**

--- a/src/main/java/net/openhft/chronicle/network/connection/AsyncTemporarySubscription.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/AsyncTemporarySubscription.java
@@ -21,6 +21,8 @@ package net.openhft.chronicle.network.connection;
  * TemporarySubscriptions are not re-established after a socket disconnection
  *
  * @author Rob Austin.
+ * @deprecated This has been moved to DataGrid without a replacement
  */
+@Deprecated(/* For removal in x.25 */)
 interface AsyncTemporarySubscription extends AsyncSubscription {
 }

--- a/src/main/java/net/openhft/chronicle/network/connection/ThreadPrivateTLongObjHashMap.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/ThreadPrivateTLongObjHashMap.java
@@ -34,11 +34,13 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Class to determine if several threads are using a TLongObjectMap.
- *
+ * <p>
  * This class should not be used in production code.
  *
  * @param <V> value type
+ * @deprecated To be removed in x.25 with no replacement
  */
+@Deprecated(/* For removal in x.25 */)
 public final class ThreadPrivateTLongObjHashMap<V> implements TLongObjectMap<V> {
 
     private final TLongObjectMap<V> delegate;
@@ -222,5 +224,5 @@ public final class ThreadPrivateTLongObjHashMap<V> implements TLongObjectMap<V> 
                         ));
             }
         }
- }
+    }
 }

--- a/src/main/java/net/openhft/chronicle/network/connection/TraceLock.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/TraceLock.java
@@ -25,6 +25,10 @@ import org.jetbrains.annotations.Nullable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
+/**
+ * @deprecated This has been moved to DataGrid without a replacement
+ */
+@Deprecated(/* For removal in x.25 */)
 class TraceLock extends ReentrantLock {
 
     private static final long serialVersionUID = 1997992705529515418L;

--- a/src/main/java/net/openhft/chronicle/network/connection/TryLock.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/TryLock.java
@@ -17,6 +17,11 @@
  */
 package net.openhft.chronicle.network.connection;
 
+
+/**
+ * @deprecated This has been moved to DataGrid without a replacement
+ */
+@Deprecated(/* For removal in x.25 */)
 public enum TryLock {
 
     LOCK, TRY_LOCK_IGNORE, TRY_LOCK_WARN

--- a/src/test/java/net/openhft/performance/tests/network/SimpleServerAndClientTest.java
+++ b/src/test/java/net/openhft/performance/tests/network/SimpleServerAndClientTest.java
@@ -46,6 +46,10 @@ import static net.openhft.chronicle.network.NetworkUtil.TCP_USE_PADDING;
 import static net.openhft.chronicle.network.connection.SocketAddressSupplier.uri;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * @deprecated This has been moved to DataGrid without a replacement
+ */
+@Deprecated(/* For removal in x.25 */)
 class SimpleServerAndClientTest extends NetworkTestCommon {
 
     @Test


### PR DESCRIPTION
Just some more classes that were either only used by `TcpChannelHub` or otherwise good to go.